### PR TITLE
Support kv/1 and kv/2

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -264,7 +264,7 @@ func (p *Provider) getSecret(token string, secretPath string, secretName string,
 		case "1":
 			var d struct {
 				Data map[string]string `json:"data"`
-			} 
+			}
 			if err := json.NewDecoder(resp.Body).Decode(&d); err != nil {
 				return "", errors.Wrapf(err, "failed to read body")
 			}

--- a/provider.go
+++ b/provider.go
@@ -350,10 +350,10 @@ func (p *Provider) MountSecretsStoreObjectContent(ctx context.Context, attrib ma
 			return err
 		}
 		objectContent := []byte(content)
-		if err := ioutil.WriteFile(path.Join(targetPath, keyValueObject.ObjectPath), objectContent, permission); err != nil {
-			return errors.Wrapf(err, "secrets-store csi driver failed to write %s at %s", keyValueObject.ObjectPath, targetPath)
+		if err := ioutil.WriteFile(path.Join(targetPath, keyValueObject.ObjectName), objectContent, permission); err != nil {
+			return errors.Wrapf(err, "secrets-store csi driver failed to write %s at %s", keyValueObject.ObjectName, targetPath)
 		}
-		klog.V(0).Infof("secrets-store csi driver wrote %s at %s", keyValueObject.ObjectPath, targetPath)
+		klog.V(0).Infof("secrets-store csi driver wrote %s at %s", keyValueObject.ObjectName, targetPath)
 	}
 
 	return nil

--- a/provider.go
+++ b/provider.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"regexp"
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
@@ -13,6 +12,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -61,7 +61,7 @@ type StringArray struct {
 }
 
 type Mount struct {
-	Type string `json:"type"`
+	Type    string            `json:"type"`
 	Options map[string]string `json:"options"`
 }
 
@@ -126,16 +126,16 @@ func (p *Provider) getMountInfo(mountName string, token string) (string, string,
 	return mount.Data[mountName+"/"].Type, mount.Data[mountName+"/"].Options["version"], nil
 }
 
-func generateSecretEndpoint(vaultAddress string, secretMountType string, secretMountVersion string, secretPrefix string, secretSuffix string, secretVersion string) (string) {
+func generateSecretEndpoint(vaultAddress string, secretMountType string, secretMountVersion string, secretPrefix string, secretSuffix string, secretVersion string) string {
 	addr := ""
 	switch secretMountType {
-		case "kv":
-			switch secretMountVersion {
-				case "1":
-					addr = vaultAddress + "/v1/" + secretPrefix + "/" + secretSuffix
-				case "2":
-					addr = vaultAddress + "/v1/" + secretPrefix + "/data/" + secretSuffix + "?version=" + secretVersion
-			}
+	case "kv":
+		switch secretMountVersion {
+		case "1":
+			addr = vaultAddress + "/v1/" + secretPrefix + "/" + secretSuffix
+		case "2":
+			addr = vaultAddress + "/v1/" + secretPrefix + "/data/" + secretSuffix + "?version=" + secretVersion
+		}
 	}
 	return addr
 }


### PR DESCRIPTION
Dynamic creates secret endpoint based on "objectPath".
Needs "read" permission on "/sys/mounts" to discovery secret mount type and version.
Writes to objectName instead of concatenate path to support nested secret path.