### PR TITLE
chore: use manifest_staging dir for yaml changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,3 +98,7 @@ clean:
 
 mod:
 	@go mod tidy
+
+promote-staging-manifest: #promote staging manifests to release dir
+	@rm -rf deployment
+	@cp -r manifest_staging/deployment .

--- a/manifest_staging/deployment/provider-vault-installer.yaml
+++ b/manifest_staging/deployment/provider-vault-installer.yaml
@@ -42,6 +42,26 @@ spec:
             - name: mountpoint-dir
               mountPath: /var/lib/kubelet/pods
               mountPropagation: HostToContainer
+          livenessProbe:
+            httpGet:
+              path: "/health/ready"
+              port: 8080
+              scheme: "HTTP"
+            failureThreshold: 2
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: "/health/ready"
+              port: 8080
+              scheme: "HTTP"
+            failureThreshold: 2
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
       volumes:
         - name: providervol
           hostPath:

--- a/manifest_staging/deployment/provider-vault-installer.yaml
+++ b/manifest_staging/deployment/provider-vault-installer.yaml
@@ -1,7 +1,33 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: secrets-store-csi-driver-provider-vault
+  name: vault-csi-provider
+  namespace: csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vault-csi-provider-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vault-csi-provider-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vault-csi-provider-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: vault-csi-provider
+  namespace: csi
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -9,6 +35,7 @@ metadata:
   labels:
     app: csi-secrets-store-provider-vault
   name: csi-secrets-store-provider-vault
+  namespace: csi
 spec:
   updateStrategy:
     type: RollingUpdate


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Adds manifest_staging dir to host yaml updates prior to release.

Fixes https://github.com/hashicorp/secrets-store-csi-driver-provider-vault/issues/74