### PR TITLE
Fix unhandled errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+BUGS:
+
+* Added missing error handling when transforming SecretProviderClass config to a Vault request [[GH-97](https://github.com/hashicorp/vault-csi-provider/pull/97)]
+
 ## 0.2.0 (April 14th, 2021)
 
 FEATURES:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,10 @@ lint:
 		--timeout 10m \
 		--enable gofmt \
 		--enable gosimple \
-		--enable govet
+		--enable govet \
+		--enable errcheck \
+		--enable ineffassign \
+		--enable unused
 
 test:
 	gotestsum --format=short-verbose $(CI_TEST_ARGS)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -48,6 +48,7 @@ func TestParseParametersFromYaml(t *testing.T) {
 	err := yaml.Unmarshal([]byte(certsSPCYaml), &secretProviderClass)
 	require.NoError(t, err)
 	paramsBytes, err := json.Marshal(secretProviderClass.Spec.Parameters)
+	require.NoError(t, err)
 
 	// This is now the form the provider receives the data in.
 	params, err := parseParameters(hclog.NewNullLogger(), string(paramsBytes))

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -142,7 +142,10 @@ func generateRequest(client *api.Client, secret config.Secret) (*api.Request, er
 		req.Params = queryParams
 	}
 	if secret.SecretArgs != nil {
-		req.SetJSONBody(secret.SecretArgs)
+		err := req.SetJSONBody(secret.SecretArgs)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return req, nil
@@ -174,6 +177,9 @@ func (p *provider) getSecret(ctx context.Context, client *api.Client, secretConf
 	key := cacheKey{secretPath: secretConfig.SecretPath, method: secretConfig.Method}
 	if secret, cached = p.cache[key]; !cached {
 		req, err := generateRequest(client, secretConfig)
+		if err != nil {
+			return "", err
+		}
 		p.logger.Debug("Requesting secret", "secretConfig", secretConfig, "method", req.Method, "path", req.URL.Path, "params", req.Params)
 
 		secret, err = vaultclient.Do(ctx, client, req)

--- a/main.go
+++ b/main.go
@@ -93,7 +93,12 @@ func realMain(logger hclog.Logger) error {
 		Addr:    *healthAddr,
 		Handler: mux,
 	}
-	defer ms.Shutdown(context.Background())
+	defer func() {
+		err := ms.Shutdown(context.Background())
+		if err != nil {
+			logger.Error("Error shutting down health handler", "err", err)
+		}
+	}()
 
 	mux.HandleFunc("/health/ready", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
#89 spotted un unhandled error. The error path should be pretty unlikely which is why I guess this was uncaught until now, but it's a pretty ugly bug nonetheless, so I've added some extra linters to our CI.

The `ineffassign` linter catches this prior to fixing (as well as one additional case), and I also added `errcheck` (which caught an additional two), and `unused` is unrelated but I added it as it seems like a nice and uncontroversial check to have.