### PR TITLE
Update versions and changelog for 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.2.1 (May 25th, 2021)
+
 BUGS:
 
 * Added missing error handling when transforming SecretProviderClass config to a Vault request [[GH-97](https://github.com/hashicorp/vault-csi-provider/pull/97)]

--- a/deployment/vault-csi-provider.yaml
+++ b/deployment/vault-csi-provider.yaml
@@ -51,7 +51,7 @@ spec:
       tolerations:
       containers:
         - name: provider-vault-installer
-          image: hashicorp/vault-csi-provider:0.2.0
+          image: hashicorp/vault-csi-provider:0.2.1
           imagePullPolicy: Always
           args:
             - --endpoint=/provider/vault.sock

--- a/manifest_staging/deployment/vault-csi-provider.yaml
+++ b/manifest_staging/deployment/vault-csi-provider.yaml
@@ -51,7 +51,7 @@ spec:
       tolerations:
       containers:
         - name: provider-vault-installer
-          image: hashicorp/vault-csi-provider:0.2.0
+          image: hashicorp/vault-csi-provider:0.2.1
           imagePullPolicy: Always
           args:
             - --endpoint=/provider/vault.sock


### PR DESCRIPTION
## BUGS:

* Added missing error handling when transforming SecretProviderClass config to a Vault request [[GH-97](https://github.com/hashicorp/vault-csi-provider/pull/97)]