### PR TITLE
Consistent flags and CI for --write-secrets=false

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,11 @@ jobs:
           command: |
             make e2e-container
             make e2e-setup
-            DISPLAY_SETUP_TEARDOWN_LOGS=true make e2e-test
+            export DISPLAY_SETUP_TEARDOWN_LOGS=true
+            make e2e-test
+            # Now switch the behaviour of --write-secrets and run the tests a second time.
+            make e2e-switch-write-secrets
+            make e2e-test
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 FEATURES:
 
-* Support for changing the default Vault address and Kubernetes mount path via CLI flag to the vault-csi-provider binary
+* Support for changing the default Vault address and Kubernetes mount path via CLI flag to the vault-csi-provider binary [[GH-96](https://github.com/hashicorp/vault-csi-provider/pull/96)]
+* Support for sending secret contents to driver for writing via `--write-secrets=false` [[GH-89](https://github.com/hashicorp/vault-csi-provider/pull/89)]
+  * **Note:** `--write-secrets=false` will become the default from v0.4.0 and require secrets-store-csi-driver v0.0.21+
+
+CHANGES:
+
+* `--health_addr` flag is marked deprecated and replaced by `--health-addr`. Slated for removal in v0.5.0 [[GH-100](https://github.com/hashicorp/vault-csi-provider/pull/100)]
 
 BUGS:
 

--- a/main_test.go
+++ b/main_test.go
@@ -15,17 +15,17 @@ func TestListen(t *testing.T) {
 	logger := hclog.NewNullLogger()
 	dir, err := ioutil.TempDir("/tmp", "TestListen")
 	require.NoError(t, err)
-	*endpoint = path.Join(dir, "vault.sock")
+	endpoint := path.Join(dir, "vault.sock")
 	defer func() {
-		require.NoError(t, os.Remove(*endpoint))
+		require.NoError(t, os.Remove(endpoint))
 	}()
 
 	// Works when no file in the way.
-	l, err := listen(logger)
+	l, err := listen(logger, endpoint)
 	require.NoError(t, err)
 
 	// Will replace existing file.
 	require.NoError(t, l.Close())
-	_, err = os.Create(*endpoint)
+	_, err = os.Create(endpoint)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
This PR makes our flags consistent on using dashes instead of underscores as with our other products. To help support that in a forwards-compatible way, I've left `--health_addr` in there for now (because it's the only underscore argument we've released) but marked it as deprecated, and if someone specifies both `--health_addr` and `--health-addr`, the one that occurs later in the command line wins.

This PR also adds a couple of `make` targets and updated CI config to support running tests with both behaviours of `--write-secrets`. It's a pretty significant change in the operation of the provider because it controls whether the provider or the driver writes the secrets, so I'd like to keep good test coverage of both flows until `--write-secrets=true` becomes a deprecated behaviour a few versions down the line.

Both of these entries will get an advanced notice in our next release changelog explaining that they will be a breaking change in a future release, but both can also be fixed by users well ahead of time once the next release is out.