### PR TITLE
Update versions and changelog for 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.3.0 (June 4th, 2021)
+
 FEATURES:
 
 * Support for changing the default Vault address and Kubernetes mount path via CLI flag to the vault-csi-provider binary [[GH-96](https://github.com/hashicorp/vault-csi-provider/pull/96)]

--- a/deployment/vault-csi-provider.yaml
+++ b/deployment/vault-csi-provider.yaml
@@ -51,7 +51,7 @@ spec:
       tolerations:
       containers:
         - name: provider-vault-installer
-          image: hashicorp/vault-csi-provider:0.2.0
+          image: hashicorp/vault-csi-provider:0.3.0
           imagePullPolicy: Always
           args:
             - --endpoint=/provider/vault.sock

--- a/manifest_staging/deployment/vault-csi-provider.yaml
+++ b/manifest_staging/deployment/vault-csi-provider.yaml
@@ -51,7 +51,7 @@ spec:
       tolerations:
       containers:
         - name: provider-vault-installer
-          image: hashicorp/vault-csi-provider:0.2.0
+          image: hashicorp/vault-csi-provider:0.3.0
           imagePullPolicy: Always
           args:
             - --endpoint=/provider/vault.sock


### PR DESCRIPTION
Getting ready to release 0.3.0

## Features

* Support for changing the default Vault address and Kubernetes mount path via CLI flag to the vault-csi-provider binary [[GH-96](https://github.com/hashicorp/vault-csi-provider/pull/96)]
* Support for sending secret contents to driver for writing via `--write-secrets=false` [[GH-89](https://github.com/hashicorp/vault-csi-provider/pull/89)]
  * **Note:** `--write-secrets=false` will become the default from v0.4.0 and require secrets-store-csi-driver v0.0.21+

## Changes

* `--health_addr` flag is marked deprecated and replaced by `--health-addr`. Slated for removal in v0.5.0 [[GH-100](https://github.com/hashicorp/vault-csi-provider/pull/100)]

## Bugs

* Added missing error handling when transforming SecretProviderClass config to a Vault request [[GH-97](https://github.com/hashicorp/vault-csi-provider/pull/97)]