### PR TITLE
Remove beta notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,6 @@
 HashiCorp [Vault](https://vaultproject.io) provider for the [Secrets Store CSI driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver) allows you to get secrets stored in
 Vault and use the Secrets Store CSI driver interface to mount them into Kubernetes pods.
 
-**This project is currently supported as a Beta product, but relies on Alpha
-Kubernetes APIs and the CSI secrets store driver which is also Alpha. Where
-possible we will provide upgrade paths and deprecation notices for future
-releases, but cannot guarantee a stable API.**
-
 ## Installation
 
 ### Prerequisites


### PR DESCRIPTION
The driver is now v1, although not all features are stable. See https://secrets-store-csi-driver.sigs.k8s.io/ for details of project status.

The features still currently in alpha are:

* Auto rotation
* Sync with Kubernetes secrets