### PR TITLE
Feature: Allow retrieval of a JSON from secretKey value

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -166,9 +166,16 @@ func keyFromData(rootData map[string]interface{}, secretKey string) (string, err
 
 	content, ok := data[secretKey].(string)
 	if !ok {
+		bytes, err := json.Marshal(data[secretKey])
+		if err == nil {
+			// Only return a valid JSON
+			// This prevents conversions of integers into string
+			if strings.Contains(string(bytes), "{") {
+				return string(bytes), nil
+			}
+		}
 		return "", fmt.Errorf("failed to get secret content %q as string", secretKey)
 	}
-
 	return content, nil
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -176,6 +176,7 @@ func keyFromData(rootData map[string]interface{}, secretKey string) (string, err
 		}
 		return "", fmt.Errorf("failed to get secret content %q as string", secretKey)
 	}
+
 	return content, nil
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -168,8 +168,7 @@ func keyFromData(rootData map[string]interface{}, secretKey string) (string, err
 	if !ok {
 		bytes, err := json.Marshal(data[secretKey])
 		if err == nil {
-			// Only return a valid JSON
-			// This prevents conversions of integers into string
+			// Return a valid JSON, prevents return of other types as string
 			if strings.Contains(string(bytes), "{") {
 				return string(bytes), nil
 			}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -254,10 +254,10 @@ func TestKeyFromData(t *testing.T) {
 			errExpected: true,
 		},
 		{
-			name:        "json data",
-			key:         "foo",
-			data:        dataWithJson,
-			expected:	 "{\"bar\":\"hop\",\"baz\":\"zap\"}",
+			name:     "json data",
+			key:      "foo",
+			data:     dataWithJson,
+			expected: "{\"bar\":\"hop\",\"baz\":\"zap\"}",
 		},
 	} {
 		content, err := keyFromData(tc.data, tc.key)

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -213,6 +213,15 @@ func TestKeyFromData(t *testing.T) {
 		"foo": 10,
 		"baz": "zap",
 	}
+	dataWithJson := map[string]interface{}{
+		"data": map[string]interface{}{
+			"foo": map[string]interface{}{
+				"bar": "hop",
+				"baz": "zap",
+			},
+			"baz": "zap",
+		},
+	}
 	for _, tc := range []struct {
 		name        string
 		key         string
@@ -243,6 +252,12 @@ func TestKeyFromData(t *testing.T) {
 			key:         "foo",
 			data:        dataWithNonStringValue,
 			errExpected: true,
+		},
+		{
+			name:        "json data",
+			key:         "foo",
+			data:        dataWithJson,
+			expected:	 "{\"bar\":\"hop\",\"baz\":\"zap\"}",
 		},
 	} {
 		content, err := keyFromData(tc.data, tc.key)


### PR DESCRIPTION
https://github.com/hashicorp/vault-csi-provider/issues/115
This issue describes how if a key with the value of a JSON is specified, it will not be successfully returned because it is not a string. However, if no `secretKey` is specified, the entire JSON response is returned, with no option for selecting a specific inner JSON. This means that the standard `data: {}, metadata: {}` response of Vault is at the top level of the JSON.


**Problem Use-case**
For a sample use-case, this means that a JSON service account secret cannot be successfully mounted into a Kubernetes pod using the vault-csi-provider, without the additional properties of the fully returned response.


**Solution**
Allow the retrieval of a JSON from the `secretKey` value.


**Updates**
- If the value of `secretKey` within the secret data is not a string,
  - Check if it is a valid JSON and return the full JSON if it is
- Test for the return of an expected JSON