### PR TITLE
Feature: Allow retrieval of a JSON from secretKey value

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -166,6 +166,13 @@ func keyFromData(rootData map[string]interface{}, secretKey string) (string, err
 
 	content, ok := data[secretKey].(string)
 	if !ok {
+		bytes, err := json.Marshal(data[secretKey])
+		if err == nil {
+			// Return a valid JSON, preventing return of other types as string
+			if strings.Contains(string(bytes), "{") {
+				return string(bytes), nil
+			}
+		}
 		return "", fmt.Errorf("failed to get secret content %q as string", secretKey)
 	}
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -213,6 +213,15 @@ func TestKeyFromData(t *testing.T) {
 		"foo": 10,
 		"baz": "zap",
 	}
+	dataWithJson := map[string]interface{}{
+		"data": map[string]interface{}{
+			"foo": map[string]interface{}{
+				"bar": "hop",
+				"baz": "zap",
+			},
+			"baz": "zap",
+		},
+	}
 	for _, tc := range []struct {
 		name        string
 		key         string
@@ -243,6 +252,12 @@ func TestKeyFromData(t *testing.T) {
 			key:         "foo",
 			data:        dataWithNonStringValue,
 			errExpected: true,
+		},
+		{
+			name:     "json data",
+			key:      "foo",
+			data:     dataWithJson,
+			expected: "{\"bar\":\"hop\",\"baz\":\"zap\"}",
 		},
 	} {
 		content, err := keyFromData(tc.data, tc.key)


### PR DESCRIPTION
https://github.com/hashicorp/vault-csi-provider/issues/115
This issue describes how if a key with the value of a JSON is specified, it will not be successfully returned because it is not a string. However, if no `secretKey` is specified, the entire JSON response is returned, with no option for selecting a specific inner JSON. This means that the standard `data: {}, metadata: {}` response of Vault is at the top level of the JSON.


**Problem Use-case**
For a sample use-case, this means that a JSON service account secret cannot be successfully mounted into a Kubernetes pod using the vault-csi-provider, without the additional properties of the fully returned response.


**Solution**
Allow the retrieval of a JSON from the `secretKey` value.


**Updates**
- If the value of `secretKey` within the secret data is not a string,
  - Check if it is a valid JSON and return the full JSON if it is
- Test for the return of an expected JSON