### PR TITLE
Support JSON values for secretKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+FEATURES:
+
+* Support extracting JSON values using `secretKey` in the SecretProviderClass [[GH-126](https://github.com/hashicorp/vault-csi-provider/pull/126)]
+
 ## 0.3.0 (June 7th, 2021)
 
 FEATURES:


### PR DESCRIPTION
Resolves #115 and based on code from #122. You can put arbitrary JSON data into `kv`'s values (and theoretically other secret engines could do the same) using a JSON file and a command like `vault kv put secret/test @test.json`, and this PR allows `vault-csi-provider` to specifically select that JSON data without having to escape your secret JSON into a big ugly string when storing it in Vault.

This PR does _not_ address arbitrary paths within the JSON though. Vault's API itself enforces that the top-level data object is a map, and users should be able to select any single top-level key from that object.

Strings remain special-cased so that we continue to write string values without wrapping them in quotes.