### PR TITLE
Flip default value for -write-secrets flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,21 @@
 ## Unreleased
 
+CHANGES:
+
+* `-write-secrets` flag now defaults to `false`, delegating file writes to the driver. [[GH-127](https://github.com/hashicorp/vault-csi-provider/pull/127)]
+  * **Note:** `-write-secrets` is deprecated and will be removed in the next major version.
+
 ## 0.3.0 (June 7th, 2021)
 
 FEATURES:
 
 * Support for changing the default Vault address and Kubernetes mount path via CLI flag to the vault-csi-provider binary [[GH-96](https://github.com/hashicorp/vault-csi-provider/pull/96)]
-* Support for sending secret contents to driver for writing via `--write-secrets=false` [[GH-89](https://github.com/hashicorp/vault-csi-provider/pull/89)]
-  * **Note:** `--write-secrets=false` will become the default from v0.4.0 and require secrets-store-csi-driver v0.0.21+
+* Support for sending secret contents to driver for writing via `-write-secrets=false` [[GH-89](https://github.com/hashicorp/vault-csi-provider/pull/89)]
+  * **Note:** `-write-secrets=false` will become the default from v0.4.0 and require secrets-store-csi-driver v0.0.21+
 
 CHANGES:
 
-* `--health_addr` flag is marked deprecated and replaced by `--health-addr`. Slated for removal in v0.5.0 [[GH-100](https://github.com/hashicorp/vault-csi-provider/pull/100)]
+* `-health_addr` flag is marked deprecated and replaced by `-health-addr`. Slated for removal in v0.5.0 [[GH-100](https://github.com/hashicorp/vault-csi-provider/pull/100)]
 
 BUGS:
 
@@ -49,7 +54,7 @@ CHANGES:
 IMPROVEMENTS
 
 * The provider now uses the `hashicorp/vault/api` package to communicate with Vault [[GH-61](https://github.com/hashicorp/vault-csi-provider/pull/61)]
-* `--version` flag will now print the version of Go used to build the provider [[GH-62](https://github.com/hashicorp/vault-csi-provider/pull/62)]
+* `-version` flag will now print the version of Go used to build the provider [[GH-62](https://github.com/hashicorp/vault-csi-provider/pull/62)]
 * CircleCI linting, tests and integration tests added [[GH-60](https://github.com/hashicorp/vault-csi-provider/pull/60)]
 
 ## 0.0.7 (January 20th, 2021)

--- a/Makefile
+++ b/Makefile
@@ -102,10 +102,10 @@ e2e-test:
 # Check the current behaviour of --write-secrets flag and switch it.
 # If the flag is missing, switch to false because the default is true.
 e2e-switch-write-secrets:
-	@if [ "$(shell kubectl get pods -n csi -l app.kubernetes.io/name=vault-csi-provider -o json | jq -r '.items[0].spec.containers[0].args[] | match("--write_secrets=(true|false)").captures[0].string')" = "false" ]; then\
-		WRITE_SECRETS=true make e2e-set-write-secrets;\
-	else\
+	@if [ "$(shell kubectl get pods -n csi -l app.kubernetes.io/name=vault-csi-provider -o json | jq -r '.items[0].spec.containers[0].args[] | match("--write_secrets=(true|false)").captures[0].string')" = "true" ]; then\
 		WRITE_SECRETS=false make e2e-set-write-secrets;\
+	else\
+		WRITE_SECRETS=true make e2e-set-write-secrets;\
 	fi
 
 e2e-set-write-secrets:

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 )
 
-const minDriverVersion = "v0.0.17"
+const minDriverVersion = "v0.0.21"
 
 var (
 	BuildDate    string

--- a/main.go
+++ b/main.go
@@ -35,10 +35,10 @@ func realMain(logger hclog.Logger) error {
 		selfVersion  = flag.Bool("version", false, "prints the version information")
 		vaultAddr    = flag.String("vault-addr", "https://127.0.0.1:8200", "default address for connecting to Vault")
 		vaultMount   = flag.String("vault-mount", "kubernetes", "default Vault mount path for Kubernetes authentication")
-		writeSecrets = flag.Bool("write-secrets", true, "write secrets directly to filesystem (true), or send secrets to CSI driver in gRPC response (false)")
+		writeSecrets = flag.Bool("write-secrets", false, "deprecated, write secrets directly to filesystem (true), or send secrets to CSI driver in gRPC response (false)")
 		healthAddr   = new(string)
 	)
-	flag.StringVar(healthAddr, "health_addr", "", "deprecated, please use --health-addr")
+	flag.StringVar(healthAddr, "health_addr", "", "deprecated, please use -health-addr")
 	flag.StringVar(healthAddr, "health-addr", ":8080", "configure http listener for reporting health")
 	flag.Parse()
 

--- a/manifest_staging/deployment/vault-csi-provider.yaml
+++ b/manifest_staging/deployment/vault-csi-provider.yaml
@@ -66,9 +66,6 @@ spec:
           volumeMounts:
             - name: providervol
               mountPath: "/provider"
-            - name: mountpoint-dir
-              mountPath: /var/lib/kubelet/pods
-              mountPropagation: HostToContainer
           livenessProbe:
             httpGet:
               path: "/health/ready"
@@ -93,8 +90,5 @@ spec:
         - name: providervol
           hostPath:
             path: "/etc/kubernetes/secrets-store-csi-providers"
-        - name: mountpoint-dir
-          hostPath:
-            path: /var/lib/kubelet/pods
       nodeSelector:
         beta.kubernetes.io/os: linux


### PR DESCRIPTION
As per the upstream driver project, sending secret contents upstream for the driver to write to file needs to become the default. This gets rid of one of the `hostPath` volumes required in the default manifest, as the provider no longer needs to directly write to pods' mounts with this default.