### PR TITLE
Use CRT for releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,14 +46,6 @@ jobs:
               exit 1
             fi
 
-  build:
-    docker:
-      - image: *GOLANG_IMAGE
-    working_directory: *WORKING_DIRECTORY
-    steps:
-      - checkout
-      - run: make build
-
   go-test:
     docker:
       - image: *GOLANG_IMAGE
@@ -114,15 +106,10 @@ workflows:
     jobs:
       - lint
       - gomod
-      - build:
-          requires:
-            - lint
-            - gomod
       - go-test:
           requires:
             - lint
             - gomod
       - integration-test:
           requires:
-            - build
             - go-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,12 +61,7 @@ jobs:
           GOARCH: ${{ matrix.arch }}
         run: |
           mkdir dist out
-          CGO_ENABLED=0 go build \
-            -ldflags "-X github.com/hashicorp/vault-csi-provider/internal/version.BuildVersion=$(make version) \
-              -X github.com/hashicorp/vault-csi-provider/internal/version.BuildDate=$(date +%Y-%m-%d-%H:%M) \
-              -X github.com/hashicorp/vault-csi-provider/internal/version.GoVersion=$(go version | cut -d' ' -f3)" \
-            -o dist/ \
-            .
+          make build
           zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip dist/
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,6 @@
 name: build
 
-on:
-  push:
-    branches:
-      - master
-      - 'release/**'
-      - crt-release
+on: push
 
 env:
   PKG_NAME: "vault-csi-provider"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,104 @@
+name: build
+
+on:
+  push:
+    branches:
+      - master
+      - 'release/**'
+      - crt-release
+
+env:
+  PKG_NAME: "vault-csi-provider"
+
+jobs:
+  get-product-version:
+    runs-on: ubuntu-latest
+    outputs:
+      product-version: ${{ steps.get-product-version.outputs.product-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: get product version
+        id: get-product-version
+        run: |
+          make version
+          echo "::set-output name=product-version::$(make version)"
+  generate-metadata-file:
+    needs: get-product-version
+    runs-on: ubuntu-latest
+    outputs:
+      filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
+    steps:
+      - name: 'Checkout directory'
+        uses: actions/checkout@v2
+      - name: Generate metadata file
+        id: generate-metadata-file
+        uses: hashicorp/actions-generate-metadata@main
+        with:
+          version: ${{ needs.get-product-version.outputs.product-version }}
+          product: ${{ env.PKG_NAME }}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: metadata.json
+          path: ${{ steps.generate-metadata-file.outputs.filepath }}
+
+  build:
+    needs: get-product-version
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ["arm", "arm64", "386", "amd64"]
+      fail-fast: true
+
+    name: Go linux ${{ matrix.arch }} build
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.17"
+
+      - name: Build
+        env:
+          GOOS: "linux"
+          GOARCH: ${{ matrix.arch }}
+        run: |
+          mkdir dist out
+          CGO_ENABLED=0 go build \
+            -ldflags "-X github.com/hashicorp/vault-csi-provider/internal/version.BuildVersion=$(make version) \
+              -X github.com/hashicorp/vault-csi-provider/internal/version.BuildDate=$(date +%Y-%m-%d-%H:%M) \
+              -X github.com/hashicorp/vault-csi-provider/internal/version.GoVersion=$(go version | cut -d' ' -f3)" \
+            -o dist/ \
+            .
+          zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip dist/
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip
+          path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip
+
+  build-docker:
+    name: Docker ${{ matrix.arch }} build
+    needs:
+      - get-product-version
+      - build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ["arm", "arm64", "386", "amd64"]
+    env:
+      repo: ${{github.event.repository.name}}
+      version: ${{needs.get-product-version.outputs.product-version}}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Docker Build (Action)
+        uses: hashicorp/actions-docker-build@v1
+        with:
+          version: ${{env.version}}
+          target: default
+          arch: ${{matrix.arch}}
+          tags: |
+            docker.io/hashicorp/${{env.repo}}:${{env.version}}
+            ecr.public.aws/hashicorp/${{env.repo}}:${{env.version}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-_output
+/dist/

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -70,7 +70,7 @@ event "security-scan-containers" {
 }
 
 event "sign" {
-  depends = ["notarize-windows-amd64"]
+  depends = ["security-scan-containers"]
   action "sign" {
     organization = "hashicorp"
     repository = "crt-workflows-common"
@@ -83,7 +83,7 @@ event "sign" {
 }
 
 event "verify" {
-  depends = ["sign-linux-rpms"]
+  depends = ["sign"]
   action "verify" {
     organization = "hashicorp"
     repository = "crt-workflows-common"

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -3,7 +3,8 @@ schema = "1"
 project "vault-csi-provider" {
   team = "vault"
   slack {
-    notification_channel = "C01A3A54G0L"
+    // #vault-releases channel
+    notification_channel = "CRF6FFKEW"
   }
   github {
     organization = "hashicorp"

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -1,0 +1,95 @@
+schema = "1"
+
+project "vault-csi-provider" {
+  team = "vault"
+  slack {
+    notification_channel = "C01A3A54G0L"
+  }
+  github {
+    organization = "hashicorp"
+    repository = "vault-csi-provider"
+    release_branches = ["master", "crt-release"]
+  }
+}
+
+event "merge" {
+  // "entrypoint" to use if build is not run automatically
+  // i.e. send "merge" complete signal to orchestrator to trigger build
+}
+
+event "build" {
+  depends = ["merge"]
+  action "build" {
+    organization = "hashicorp"
+    repository = "vault-csi-provider"
+    workflow = "build"
+  }
+}
+
+event "upload-dev" {
+  depends = ["build"]
+  action "upload-dev" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "upload-dev"
+    depends = ["build"]
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "security-scan-binaries" {
+  depends = ["upload-dev"]
+  action "security-scan-binaries" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "security-scan-binaries"
+    config = "security-scan.hcl"
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "security-scan-containers" {
+  depends = ["security-scan-binaries"]
+  action "security-scan-containers" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "security-scan-containers"
+    config = "security-scan.hcl"
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "sign" {
+  depends = ["notarize-windows-amd64"]
+  action "sign" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "sign"
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "verify" {
+  depends = ["sign-linux-rpms"]
+  action "verify" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "verify"
+  }
+
+  notification {
+    on = "always"
+  }
+}

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -9,7 +9,7 @@ project "vault-csi-provider" {
   github {
     organization = "hashicorp"
     repository = "vault-csi-provider"
-    release_branches = ["master"]
+    release_branches = ["main"]
   }
 }
 

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -9,7 +9,7 @@ project "vault-csi-provider" {
   github {
     organization = "hashicorp"
     repository = "vault-csi-provider"
-    release_branches = ["master", "crt-release"]
+    release_branches = ["master"]
   }
 }
 

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -1,0 +1,13 @@
+container {
+	dependencies = true
+	alpine_secdb = true
+	secrets      = true
+}
+
+binary {
+	secrets      = true
+	go_modules   = true
+	osv          = true
+	oss_index    = false
+	nvd          = false
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,39 @@
-FROM docker.mirror.hashicorp.services/alpine:3.14
+# This Dockerfile contains multiple targets.
+# Use 'docker build --target=<name> .' to build one.
 
-ARG VERSION
-ARG ARCH="amd64"
-ARG OS="linux"
+# devbuild compiles the binary
+# -----------------------------------
+FROM docker.mirror.hashicorp.services/golang:latest AS devbuild
+ENV CGO_ENABLED=0
+# Leave the GOPATH
+WORKDIR /build
+COPY . ./
+RUN go build -o vault-csi-provider
 
-COPY ./_output/vault-csi-provider_${OS}_${ARCH}_${VERSION} /bin/vault-csi-provider
+# dev runs the binary from devbuild
+# -----------------------------------
+FROM docker.mirror.hashicorp.services/alpine:latest AS dev
+COPY --from=devbuild /build/vault-csi-provider /bin/
+ENTRYPOINT [ "/bin/vault-csi-provider" ]
 
-ENTRYPOINT ["/bin/vault-csi-provider"]
+# Default release image.
+# -----------------------------------
+FROM docker.mirror.hashicorp.services/alpine:latest AS default
+
+ARG PRODUCT_VERSION
+ARG PRODUCT_REVISION
+ARG PRODUCT_NAME=vault-csi-provider
+ARG TARGETOS TARGETARCH
+
+LABEL version=$PRODUCT_VERSION
+LABEL revision=$PRODUCT_REVISION
+
+COPY dist/$TARGETOS/$TARGETARCH/vault-csi-provider /bin/
+ENTRYPOINT [ "/bin/vault-csi-provider" ]
+
+# ===================================
+# 
+#   Set default target to 'dev'.
+#
+# ===================================
+FROM dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 # devbuild compiles the binary
 # -----------------------------------
-FROM docker.mirror.hashicorp.services/golang:latest AS devbuild
+FROM docker.mirror.hashicorp.services/golang:1.17.6 AS devbuild
 ENV CGO_ENABLED=0
 # Leave the GOPATH
 WORKDIR /build
@@ -12,13 +12,13 @@ RUN go build -o vault-csi-provider
 
 # dev runs the binary from devbuild
 # -----------------------------------
-FROM docker.mirror.hashicorp.services/alpine:latest AS dev
+FROM docker.mirror.hashicorp.services/alpine:3.15.0 AS dev
 COPY --from=devbuild /build/vault-csi-provider /bin/
 ENTRYPOINT [ "/bin/vault-csi-provider" ]
 
 # Default release image.
 # -----------------------------------
-FROM docker.mirror.hashicorp.services/alpine:latest AS default
+FROM docker.mirror.hashicorp.services/alpine:3.15.0 AS default
 
 ARG PRODUCT_VERSION
 ARG PRODUCT_REVISION

--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,10 @@ BUILD_DATE=$$(date +%Y-%m-%d-%H:%M)
 LDFLAGS?="-X 'github.com/hashicorp/vault-csi-provider/internal/version.BuildVersion=$(VERSION)' \
 	-X 'github.com/hashicorp/vault-csi-provider/internal/version.BuildDate=$(BUILD_DATE)' \
 	-X 'github.com/hashicorp/vault-csi-provider/internal/version.GoVersion=$(shell go version)'"
-GOOS?=linux
-GOARCH?=amd64
-GOLANG_IMAGE?=docker.mirror.hashicorp.services/golang:1.17.2
 K8S_VERSION?=v1.22.2
 CSI_DRIVER_VERSION=1.0.0
 VAULT_HELM_VERSION=0.16.1
 CI_TEST_ARGS?=
-XC_PUBLISH?=
-PUBLISH_LOCATION?=https://releases.hashicorp.com
 
 .PHONY: default build test lint image e2e-container e2e-setup e2e-teardown e2e-test e2e-switch-write-secrets e2e-set-write-secrets mod setup-kind version promote-staging-manifest
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CI_TEST_ARGS?=
 XC_PUBLISH?=
 PUBLISH_LOCATION?=https://releases.hashicorp.com
 
-.PHONY: all test lint image e2e-container e2e-setup e2e-teardown e2e-test clean setup mod setup-kind version
+.PHONY: default build test lint image e2e-container e2e-setup e2e-teardown e2e-test e2e-switch-write-secrets e2e-set-write-secrets mod setup-kind version promote-staging-manifest
 
 GO111MODULE?=on
 export GO111MODULE
@@ -35,6 +35,12 @@ lint:
 		--enable errcheck \
 		--enable ineffassign \
 		--enable unused
+
+build:
+	CGO_ENABLED=0 go build \
+		-ldflags $(LDFLAGS) \
+		-o dist/ \
+		.
 
 test:
 	gotestsum --format=short-verbose $(CI_TEST_ARGS)
@@ -94,9 +100,6 @@ e2e-set-write-secrets:
 		--namespace=csi \
 		--values=test/bats/configs/vault/vault.values.yaml \
 		--set "csi.extraArgs={--write-secrets=$(WRITE_SECRETS)}";\
-
-clean:
-	-rm -rf _output
 
 mod:
 	@go mod tidy


### PR DESCRIPTION
Updates to use CRT for releases:

* New GitHub action to create the artefacts for promotion
* New CRT config files
* Dockerfile restructured for dev/CI targets
* Various Makefile updates