### PR TITLE
Prepare to release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.4.0 (January 12th, 2022)
+
 CHANGES:
 
 * `-write-secrets` flag now defaults to `false`, delegating file writes to the driver. [[GH-127](https://github.com/hashicorp/vault-csi-provider/pull/127)]

--- a/deployment/vault-csi-provider.yaml
+++ b/deployment/vault-csi-provider.yaml
@@ -51,7 +51,7 @@ spec:
       tolerations:
       containers:
         - name: provider-vault-installer
-          image: hashicorp/vault-csi-provider:0.3.0
+          image: hashicorp/vault-csi-provider:0.4.0
           imagePullPolicy: Always
           args:
             - -endpoint=/provider/vault.sock
@@ -66,9 +66,6 @@ spec:
           volumeMounts:
             - name: providervol
               mountPath: "/provider"
-            - name: mountpoint-dir
-              mountPath: /var/lib/kubelet/pods
-              mountPropagation: HostToContainer
           livenessProbe:
             httpGet:
               path: "/health/ready"
@@ -93,8 +90,5 @@ spec:
         - name: providervol
           hostPath:
             path: "/etc/kubernetes/secrets-store-csi-providers"
-        - name: mountpoint-dir
-          hostPath:
-            path: /var/lib/kubelet/pods
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/manifest_staging/deployment/vault-csi-provider.yaml
+++ b/manifest_staging/deployment/vault-csi-provider.yaml
@@ -51,7 +51,7 @@ spec:
       tolerations:
       containers:
         - name: provider-vault-installer
-          image: hashicorp/vault-csi-provider:0.3.0
+          image: hashicorp/vault-csi-provider:0.4.0
           imagePullPolicy: Always
           args:
             - -endpoint=/provider/vault.sock


### PR DESCRIPTION
Getting the repo ready to trigger the release process. This could have easily been 1.0.0, but the plan is to save that for the second run of the new release process, and most likely try to keep changes to a minimum too.