### PR TITLE
Deprecate -write-secrets and -health_addr flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,9 +96,6 @@ jobs:
             make e2e-setup
             export DISPLAY_SETUP_TEARDOWN_LOGS=true
             make e2e-test
-            # Now switch the behaviour of --write-secrets and run the tests a second time.
-            make e2e-switch-write-secrets
-            make e2e-test
 
 workflows:
   version: 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,4 +91,3 @@ jobs:
           arch: ${{matrix.arch}}
           tags: |
             docker.io/hashicorp/${{env.repo}}:${{env.version}}
-            ecr.public.aws/hashicorp/${{env.repo}}:${{env.version}}

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -91,6 +91,6 @@ event "verify" {
   }
 
   notification {
-    on = "always"
+    on = "fail"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+CHANGES:
+
+* `-write-secrets` flag removed. All secrets are now written to the filesystem by the CSI secrets store driver. [[GH-133](https://github.com/hashicorp/vault-csi-provider/pull/133)]
+  * **NOTE:** CSI secrets store driver v0.0.21+ is required.
+* `-health_addr` flag removed, use `-health-addr` instead. [[GH-133](https://github.com/hashicorp/vault-csi-provider/pull/133)]
+
 ## 0.4.0 (January 12th, 2022)
 
 CHANGES:

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -227,7 +227,7 @@ func (p *provider) getSecret(ctx context.Context, client *api.Client, secretConf
 }
 
 // MountSecretsStoreObjectContent mounts content of the vault object to target path
-func (p *provider) HandleMountRequest(ctx context.Context, cfg config.Config, writeSecrets bool) (*pb.MountResponse, error) {
+func (p *provider) HandleMountRequest(ctx context.Context, cfg config.Config) (*pb.MountResponse, error) {
 	versions := make(map[string]string)
 
 	client, err := vaultclient.New(cfg.Parameters.VaultAddress, cfg.Parameters.VaultTLSConfig)
@@ -255,15 +255,8 @@ func (p *provider) HandleMountRequest(ctx context.Context, cfg config.Config, wr
 		}
 		versions[fmt.Sprintf("%s:%s:%s", secret.ObjectName, secret.SecretPath, secret.Method)] = "0"
 
-		if writeSecrets {
-			err = writeSecret(p.logger, cfg.TargetPath, secret.ObjectName, content, cfg.FilePermission)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			files = append(files, &pb.File{Path: secret.ObjectName, Mode: int32(cfg.FilePermission), Contents: content})
-			p.logger.Info("secret added to mount response", "directory", cfg.TargetPath, "file", secret.ObjectName)
-		}
+		files = append(files, &pb.File{Path: secret.ObjectName, Mode: int32(cfg.FilePermission), Contents: content})
+		p.logger.Info("secret added to mount response", "directory", cfg.TargetPath, "file", secret.ObjectName)
 	}
 
 	var ov []*pb.ObjectVersion

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,10 +17,9 @@ var (
 
 // Server implements the secrets-store-csi-driver provider gRPC service interface.
 type Server struct {
-	Logger       hclog.Logger
-	VaultAddr    string
-	VaultMount   string
-	WriteSecrets bool
+	Logger     hclog.Logger
+	VaultAddr  string
+	VaultMount string
 }
 
 func (p *Server) Version(context.Context, *pb.VersionRequest) (*pb.VersionResponse, error) {
@@ -38,7 +37,7 @@ func (p *Server) Mount(ctx context.Context, req *pb.MountRequest) (*pb.MountResp
 	}
 
 	provider := provider.NewProvider(p.Logger.Named("provider"))
-	resp, err := provider.HandleMountRequest(ctx, cfg, p.WriteSecrets)
+	resp, err := provider.HandleMountRequest(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("error making mount request: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -30,16 +30,13 @@ func main() {
 
 func realMain(logger hclog.Logger) error {
 	var (
-		endpoint     = flag.String("endpoint", "/tmp/vault.sock", "path to socket on which to listen for driver gRPC calls")
-		debug        = flag.Bool("debug", false, "sets log to debug level")
-		selfVersion  = flag.Bool("version", false, "prints the version information")
-		vaultAddr    = flag.String("vault-addr", "https://127.0.0.1:8200", "default address for connecting to Vault")
-		vaultMount   = flag.String("vault-mount", "kubernetes", "default Vault mount path for Kubernetes authentication")
-		writeSecrets = flag.Bool("write-secrets", false, "deprecated, write secrets directly to filesystem (true), or send secrets to CSI driver in gRPC response (false)")
-		healthAddr   = new(string)
+		endpoint    = flag.String("endpoint", "/tmp/vault.sock", "path to socket on which to listen for driver gRPC calls")
+		debug       = flag.Bool("debug", false, "sets log to debug level")
+		selfVersion = flag.Bool("version", false, "prints the version information")
+		vaultAddr   = flag.String("vault-addr", "https://127.0.0.1:8200", "default address for connecting to Vault")
+		vaultMount  = flag.String("vault-mount", "kubernetes", "default Vault mount path for Kubernetes authentication")
+		healthAddr  = flag.String("health-addr", ":8080", "configure http listener for reporting health")
 	)
-	flag.StringVar(healthAddr, "health_addr", "", "deprecated, please use -health-addr")
-	flag.StringVar(healthAddr, "health-addr", ":8080", "configure http listener for reporting health")
 	flag.Parse()
 
 	// set log level
@@ -86,10 +83,9 @@ func realMain(logger hclog.Logger) error {
 	defer listener.Close()
 
 	s := &providerserver.Server{
-		Logger:       serverLogger,
-		VaultAddr:    *vaultAddr,
-		VaultMount:   *vaultMount,
-		WriteSecrets: *writeSecrets,
+		Logger:     serverLogger,
+		VaultAddr:  *vaultAddr,
+		VaultMount: *vaultMount,
 	}
 	pb.RegisterCSIDriverProviderServer(server, s)
 


### PR DESCRIPTION
Preparing for v1.0.0 by removing deprecated flags. These have previously been marked deprecated in the changelog and release notes.