### PR TITLE
Support configuring all Vault connection details in flags

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,18 +6,49 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/hashicorp/vault/api"
 	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// Config represents all of the provider's configurable behaviour from the MountRequest proto message:
+// Config represents all of the provider's configurable behaviour from the SecretProviderClass,
+// transmitted in the MountRequest proto message:
 // * Parameters from the `Attributes` field.
 // * Plus the rest of the proto fields we consume.
 // See sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1/service.pb.go
 type Config struct {
-	Parameters
+	Parameters     Parameters
 	TargetPath     string
 	FilePermission os.FileMode
+}
+
+type FlagsConfig struct {
+	Endpoint   string
+	Debug      bool
+	Version    bool
+	HealthAddr string
+
+	VaultAddr      string
+	VaultMount     string
+	VaultNamespace string
+
+	TLSCACertPath  string
+	TLSCADirectory string
+	TLSServerName  string
+	TLSClientCert  string
+	TLSClientKey   string
+	TLSSkipVerify  bool
+}
+
+func (fc FlagsConfig) TLSConfig() api.TLSConfig {
+	return api.TLSConfig{
+		CACert:        fc.TLSCACertPath,
+		CAPath:        fc.TLSCADirectory,
+		ClientCert:    fc.TLSClientCert,
+		ClientKey:     fc.TLSClientKey,
+		TLSServerName: fc.TLSServerName,
+		Insecure:      fc.TLSSkipVerify,
+	}
 }
 
 // Parameters stores the parameters specified in a mount request's `Attributes` field.
@@ -34,18 +65,9 @@ type Parameters struct {
 	VaultRoleName            string
 	VaultKubernetesMountPath string
 	VaultNamespace           string
-	VaultTLSConfig           TLSConfig
+	VaultTLSConfig           api.TLSConfig
 	Secrets                  []Secret
 	PodInfo                  PodInfo
-}
-
-type TLSConfig struct {
-	CACertPath     string
-	CADirectory    string
-	TLSServerName  string
-	SkipVerify     bool
-	ClientCertPath string
-	ClientKeyPath  string
 }
 
 type PodInfo struct {
@@ -63,31 +85,29 @@ type Secret struct {
 	SecretArgs map[string]interface{} `yaml:"secretArgs,omitempty"`
 }
 
-func Parse(parametersStr, targetPath, permissionStr string, defaultVaultAddr string, defaultVaultKubernetesMountPath string) (Config, error) {
+func Parse(parametersStr, targetPath, permissionStr string) (Config, error) {
 	config := Config{
 		TargetPath: targetPath,
 	}
 
 	var err error
-	config.Parameters, err = parseParameters(parametersStr, defaultVaultAddr, defaultVaultKubernetesMountPath)
+	config.Parameters, err = parseParameters(parametersStr)
 	if err != nil {
 		return Config{}, err
 	}
 
-	err = json.Unmarshal([]byte(permissionStr), &config.FilePermission)
-	if err != nil {
+	if err := json.Unmarshal([]byte(permissionStr), &config.FilePermission); err != nil {
 		return Config{}, err
 	}
 
-	err = config.validate()
-	if err != nil {
+	if err := config.validate(); err != nil {
 		return Config{}, err
 	}
 
 	return config, nil
 }
 
-func parseParameters(parametersStr string, defaultVaultAddress string, defaultVaultKubernetesMountPath string) (Parameters, error) {
+func parseParameters(parametersStr string) (Parameters, error) {
 	var params map[string]string
 	err := json.Unmarshal([]byte(parametersStr), &params)
 	if err != nil {
@@ -98,11 +118,11 @@ func parseParameters(parametersStr string, defaultVaultAddress string, defaultVa
 	parameters.VaultRoleName = params["roleName"]
 	parameters.VaultAddress = params["vaultAddress"]
 	parameters.VaultNamespace = params["vaultNamespace"]
-	parameters.VaultTLSConfig.CACertPath = params["vaultCACertPath"]
-	parameters.VaultTLSConfig.CADirectory = params["vaultCADirectory"]
+	parameters.VaultTLSConfig.CACert = params["vaultCACertPath"]
+	parameters.VaultTLSConfig.CAPath = params["vaultCADirectory"]
 	parameters.VaultTLSConfig.TLSServerName = params["vaultTLSServerName"]
-	parameters.VaultTLSConfig.ClientCertPath = params["vaultTLSClientCertPath"]
-	parameters.VaultTLSConfig.ClientKeyPath = params["vaultTLSClientKeyPath"]
+	parameters.VaultTLSConfig.ClientCert = params["vaultTLSClientCertPath"]
+	parameters.VaultTLSConfig.ClientKey = params["vaultTLSClientKeyPath"]
 	parameters.VaultKubernetesMountPath = params["vaultKubernetesMountPath"]
 	parameters.PodInfo.Name = params["csi.storage.k8s.io/pod.name"]
 	parameters.PodInfo.UID = types.UID(params["csi.storage.k8s.io/pod.uid"])
@@ -111,7 +131,7 @@ func parseParameters(parametersStr string, defaultVaultAddress string, defaultVa
 	if skipTLS, ok := params["vaultSkipTLSVerify"]; ok {
 		value, err := strconv.ParseBool(skipTLS)
 		if err == nil {
-			parameters.VaultTLSConfig.SkipVerify = value
+			parameters.VaultTLSConfig.Insecure = value
 		} else {
 			return Parameters{}, err
 		}
@@ -121,15 +141,6 @@ func parseParameters(parametersStr string, defaultVaultAddress string, defaultVa
 	err = yaml.Unmarshal([]byte(secretsYaml), &parameters.Secrets)
 	if err != nil {
 		return Parameters{}, err
-	}
-
-	// Set default values.
-	if parameters.VaultAddress == "" {
-		parameters.VaultAddress = defaultVaultAddress
-	}
-
-	if parameters.VaultKubernetesMountPath == "" {
-		parameters.VaultKubernetesMountPath = defaultVaultKubernetesMountPath
 	}
 
 	return parameters, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -34,8 +35,6 @@ spec:
           common_name: "internal.example.com"
         method: "PUT"
 `
-	defaultVaultAddress             = "http://127.0.0.1:8200"
-	defaultVaultKubernetesMountPath = "kubernetes"
 )
 
 func TestParseParametersFromYaml(t *testing.T) {
@@ -52,12 +51,10 @@ func TestParseParametersFromYaml(t *testing.T) {
 	require.NoError(t, err)
 
 	// This is now the form the provider receives the data in.
-	params, err := parseParameters(string(paramsBytes), defaultVaultAddress, defaultVaultKubernetesMountPath)
+	params, err := parseParameters(string(paramsBytes))
 	require.NoError(t, err)
 
 	require.Equal(t, Parameters{
-		VaultAddress:             defaultVaultAddress,
-		VaultKubernetesMountPath: defaultVaultKubernetesMountPath,
 		Secrets: []Secret{
 			{
 				ObjectName: "test-certs",
@@ -86,19 +83,18 @@ func TestParseParameters(t *testing.T) {
 	// This file's contents are copied directly from a driver mount request.
 	parametersStr, err := ioutil.ReadFile(filepath.Join("testdata", "example-parameters-string.txt"))
 	require.NoError(t, err)
-	actual, err := parseParameters(string(parametersStr), defaultVaultAddress, defaultVaultKubernetesMountPath)
+	actual, err := parseParameters(string(parametersStr))
 	require.NoError(t, err)
 	expected := Parameters{
 		VaultRoleName: "example-role",
 		VaultAddress:  "http://vault:8200",
-		VaultTLSConfig: TLSConfig{
-			SkipVerify: true,
+		VaultTLSConfig: api.TLSConfig{
+			Insecure: true,
 		},
 		Secrets: []Secret{
 			{"bar1", "v1/secret/foo1", "", "GET", nil},
 			{"bar2", "v1/secret/foo2", "", "", nil},
 		},
-		VaultKubernetesMountPath: defaultVaultKubernetesMountPath,
 		PodInfo: PodInfo{
 			Name:               "nginx-secrets-store-inline",
 			UID:                "9aeb260f-d64a-426c-9872-95b6bab37e00",
@@ -112,11 +108,6 @@ func TestParseParameters(t *testing.T) {
 func TestParseConfig(t *testing.T) {
 	const roleName = "example-role"
 	const targetPath = "/some/path"
-	defaultParams := Parameters{
-		VaultAddress:             defaultVaultAddress,
-		VaultKubernetesMountPath: defaultVaultKubernetesMountPath,
-		VaultNamespace:           "",
-	}
 	for _, tc := range []struct {
 		name       string
 		targetPath string
@@ -135,9 +126,9 @@ func TestParseConfig(t *testing.T) {
 				TargetPath:     targetPath,
 				FilePermission: 420,
 				Parameters: func() Parameters {
-					expected := defaultParams
+					expected := Parameters{}
 					expected.VaultRoleName = roleName
-					expected.VaultTLSConfig.SkipVerify = true
+					expected.VaultTLSConfig.Insecure = true
 					expected.Secrets = []Secret{
 						{"bar1", "v1/secret/foo1", "", "", nil},
 					}
@@ -146,38 +137,57 @@ func TestParseConfig(t *testing.T) {
 			},
 		},
 		{
-			name:       "non-defaults can be set",
+			name:       "set all options",
 			targetPath: targetPath,
 			parameters: map[string]string{
-				"roleName":                     "example-role",
-				"vaultSkipTLSVerify":           "true",
-				"vaultAddress":                 "my-vault-address",
-				"vaultNamespace":               "my-vault-namespace",
-				"vaultKubernetesMountPath":     "my-mount-path",
-				"KubernetesServiceAccountPath": "my-account-path",
-				"objects":                      objects,
+				"roleName":                               "example-role",
+				"vaultSkipTLSVerify":                     "true",
+				"vaultAddress":                           "my-vault-address",
+				"vaultNamespace":                         "my-vault-namespace",
+				"vaultKubernetesMountPath":               "my-mount-path",
+				"vaultCACertPath":                        "my-ca-cert-path",
+				"vaultCADirectory":                       "my-ca-directory",
+				"vaultTLSServerName":                     "mytls-server-name",
+				"vaultTLSClientCertPath":                 "my-tls-client-cert-path",
+				"vaultTLSClientKeyPath":                  "my-tls-client-key-path",
+				"csi.storage.k8s.io/pod.name":            "my-pod-name",
+				"csi.storage.k8s.io/pod.uid":             "my-pod-uid",
+				"csi.storage.k8s.io/pod.namespace":       "my-pod-namespace",
+				"csi.storage.k8s.io/serviceAccount.name": "my-pod-sa-name",
+				"objects":                                objects,
 			},
 			expected: Config{
 				TargetPath:     targetPath,
 				FilePermission: 420,
-				Parameters: func() Parameters {
-					expected := defaultParams
-					expected.VaultRoleName = roleName
-					expected.VaultAddress = "my-vault-address"
-					expected.VaultNamespace = "my-vault-namespace"
-					expected.VaultKubernetesMountPath = "my-mount-path"
-					expected.VaultTLSConfig.SkipVerify = true
-					expected.Secrets = []Secret{
+				Parameters: Parameters{
+					VaultRoleName:            roleName,
+					VaultAddress:             "my-vault-address",
+					VaultNamespace:           "my-vault-namespace",
+					VaultKubernetesMountPath: "my-mount-path",
+					Secrets: []Secret{
 						{"bar1", "v1/secret/foo1", "", "", nil},
-					}
-					return expected
-				}(),
+					},
+					VaultTLSConfig: api.TLSConfig{
+						CACert:        "my-ca-cert-path",
+						CAPath:        "my-ca-directory",
+						ClientCert:    "my-tls-client-cert-path",
+						ClientKey:     "my-tls-client-key-path",
+						TLSServerName: "mytls-server-name",
+						Insecure:      true,
+					},
+					PodInfo: PodInfo{
+						"my-pod-name",
+						"my-pod-uid",
+						"my-pod-namespace",
+						"my-pod-sa-name",
+					},
+				},
 			},
 		},
 	} {
 		parametersStr, err := json.Marshal(tc.parameters)
 		require.NoError(t, err)
-		cfg, err := Parse(string(parametersStr), tc.targetPath, "420", defaultVaultAddress, defaultVaultKubernetesMountPath)
+		cfg, err := Parse(string(parametersStr), tc.targetPath, "420")
 		require.NoError(t, err, tc.name)
 		require.Equal(t, tc.expected, cfg)
 	}
@@ -207,7 +217,7 @@ func TestParseConfig_Errors(t *testing.T) {
 	} {
 		parametersStr, err := json.Marshal(tc.parameters)
 		require.NoError(t, err)
-		_, err = Parse(string(parametersStr), "/some/path", "420", defaultVaultAddress, defaultVaultKubernetesMountPath)
+		_, err = Parse(string(parametersStr), "/some/path", "420")
 		require.Error(t, err, tc.name)
 	}
 }
@@ -216,7 +226,7 @@ func TestValidateConfig(t *testing.T) {
 	minimumValid := Config{
 		TargetPath: "a",
 		Parameters: Parameters{
-			VaultAddress:  defaultVaultAddress,
+			VaultAddress:  "http://127.0.0.1:8200",
 			VaultRoleName: "b",
 			Secrets:       []Secret{{}},
 		},
@@ -235,7 +245,7 @@ func TestValidateConfig(t *testing.T) {
 			name: "No role name",
 			cfg: func() Config {
 				cfg := minimumValid
-				cfg.VaultRoleName = ""
+				cfg.Parameters.VaultRoleName = ""
 				return cfg
 			}(),
 		},
@@ -251,7 +261,7 @@ func TestValidateConfig(t *testing.T) {
 			name: "No secrets configured",
 			cfg: func() Config {
 				cfg := minimumValid
-				cfg.Secrets = []Secret{}
+				cfg.Parameters.Secrets = []Secret{}
 				return cfg
 			}(),
 		},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -227,18 +227,17 @@ func (p *provider) getSecret(ctx context.Context, client *api.Client, secretConf
 }
 
 // MountSecretsStoreObjectContent mounts content of the vault object to target path
-func (p *provider) HandleMountRequest(ctx context.Context, cfg config.Config) (*pb.MountResponse, error) {
+func (p *provider) HandleMountRequest(ctx context.Context, cfg config.Config, flagsConfig config.FlagsConfig) (*pb.MountResponse, error) {
 	versions := make(map[string]string)
 
-	client, err := vaultclient.New(cfg.Parameters.VaultAddress, cfg.Parameters.VaultTLSConfig)
+	client, err := vaultclient.New(cfg.Parameters, flagsConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	// Set Vault namespace if configured
-	if cfg.VaultNamespace != "" {
-		p.logger.Debug("setting Vault namespace", "namespace", cfg.VaultNamespace)
-		client.SetNamespace(cfg.VaultNamespace)
+	// Set default k8s auth path if unset.
+	if cfg.Parameters.VaultKubernetesMountPath == "" {
+		cfg.Parameters.VaultKubernetesMountPath = flagsConfig.VaultMount
 	}
 
 	// Authenticate to vault using the jwt token

--- a/test/bats/configs/nginx/templates/nginix.yaml
+++ b/test/bats/configs/nginx/templates/nginix.yaml
@@ -12,6 +12,7 @@ spec:
   terminationGracePeriodSeconds: 0
   containers:
   - image: docker.mirror.hashicorp.services/nginx
+    imagePullPolicy: IfNotPresent
     name: nginx
     volumeMounts:
     - name: secrets-store-inline

--- a/test/bats/configs/vault-kv-secretproviderclass.yaml
+++ b/test/bats/configs/vault-kv-secretproviderclass.yaml
@@ -7,10 +7,6 @@ spec:
   provider: vault
   parameters:
     roleName: "kv-role"
-    vaultAddress: https://vault:8200
-    vaultCACertPath: /mnt/tls/ca.crt
-    vaultTLSClientCertPath: /mnt/tls/client.crt
-    vaultTLSClientKeyPath: /mnt/tls/client.key
     objects: |
       - objectName: "secret-1"
         secretPath: "secret/data/kv1"

--- a/test/bats/configs/vault/vault.values.yaml
+++ b/test/bats/configs/vault/vault.values.yaml
@@ -47,6 +47,11 @@ server:
 csi:
   enabled: true
   debug: true
+  extraArgs:
+    - -vault-addr=https://vault:8200
+    - -vault-tls-ca-cert=/mnt/tls/ca.crt
+    - -vault-tls-client-cert=/mnt/tls/client.crt
+    - -vault-tls-client-key=/mnt/tls/client.key
 
   image:
     repository: "e2e/vault-csi-provider"


### PR DESCRIPTION
Closes #82 
Adds flags to configure Vault TLS and namespace settings in addition to the existing options to use environment variables and SPC parameters. We already allowed using env vars due to using `api.DefaultConfig()`, but hadn't actually documented this anywhere. Config precedence follows the level of specificity, so SPC > flag > env var.

I also replaced usage of this repo's `config.TLSConfig` with the Vault API module's `api.TLSConfig`, which is the same struct with slightly different member names.