### PR TITLE
Support file permission setting in SPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ IMPROVEMENTS:
   * `-vault-tls-client-cert`
   * `-vault-tls-client-key`
   * `-vault-tls-skip-verify`
+* New SecretProviderClass field `filePermission` can be used per-secret to set the file permissions it is written with. [[GH-139](https://github.com/hashicorp/vault-csi-provider/pull/139)]
 
 ## 1.0.0 (January 25th, 2022)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/vault-csi-provider
 
-go 1.12
+go 1.13
 
 require (
 	github.com/hashicorp/go-hclog v1.0.0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,11 +56,12 @@ type PodInfo struct {
 }
 
 type Secret struct {
-	ObjectName string                 `yaml:"objectName,omitempty"`
-	SecretPath string                 `yaml:"secretPath,omitempty"`
-	SecretKey  string                 `yaml:"secretKey,omitempty"`
-	Method     string                 `yaml:"method,omitempty"`
-	SecretArgs map[string]interface{} `yaml:"secretArgs,omitempty"`
+	ObjectName     string                 `yaml:"objectName,omitempty"`
+	SecretPath     string                 `yaml:"secretPath,omitempty"`
+	SecretKey      string                 `yaml:"secretKey,omitempty"`
+	Method         string                 `yaml:"method,omitempty"`
+	SecretArgs     map[string]interface{} `yaml:"secretArgs,omitempty"`
+	FilePermission os.FileMode            `yaml:"filePermission,omitempty"`
 }
 
 func Parse(parametersStr, targetPath, permissionStr string, defaultVaultAddr string, defaultVaultKubernetesMountPath string) (Config, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	objects      = "-\n  secretPath: \"v1/secret/foo1\"\n  objectName: \"bar1\""
+	objects      = "-\n  secretPath: \"v1/secret/foo1\"\n  objectName: \"bar1\"\n  filePermission: 0600"
 	certsSPCYaml = `apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
@@ -95,8 +95,8 @@ func TestParseParameters(t *testing.T) {
 			SkipVerify: true,
 		},
 		Secrets: []Secret{
-			{"bar1", "v1/secret/foo1", "", "GET", nil},
-			{"bar2", "v1/secret/foo2", "", "", nil},
+			{"bar1", "v1/secret/foo1", "", "GET", nil, 0},
+			{"bar2", "v1/secret/foo2", "", "", nil, 0},
 		},
 		VaultKubernetesMountPath: defaultVaultKubernetesMountPath,
 		PodInfo: PodInfo{
@@ -139,7 +139,7 @@ func TestParseConfig(t *testing.T) {
 					expected.VaultRoleName = roleName
 					expected.VaultTLSConfig.SkipVerify = true
 					expected.Secrets = []Secret{
-						{"bar1", "v1/secret/foo1", "", "", nil},
+						{"bar1", "v1/secret/foo1", "", "", nil, 0o600},
 					}
 					return expected
 				}(),
@@ -168,7 +168,7 @@ func TestParseConfig(t *testing.T) {
 					expected.VaultKubernetesMountPath = "my-mount-path"
 					expected.VaultTLSConfig.SkipVerify = true
 					expected.Secrets = []Secret{
-						{"bar1", "v1/secret/foo1", "", "", nil},
+						{"bar1", "v1/secret/foo1", "", "", nil, 0o600},
 					}
 					return expected
 				}(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -255,7 +255,11 @@ func (p *provider) HandleMountRequest(ctx context.Context, cfg config.Config) (*
 		}
 		versions[fmt.Sprintf("%s:%s:%s", secret.ObjectName, secret.SecretPath, secret.Method)] = "0"
 
-		files = append(files, &pb.File{Path: secret.ObjectName, Mode: int32(cfg.FilePermission), Contents: content})
+		filePermission := int32(cfg.FilePermission)
+		if secret.FilePermission != 0 {
+			filePermission = int32(secret.FilePermission)
+		}
+		files = append(files, &pb.File{Path: secret.ObjectName, Mode: filePermission, Contents: content})
 		p.logger.Info("secret added to mount response", "directory", cfg.TargetPath, "file", secret.ObjectName)
 	}
 

--- a/test/bats/configs/vault-kv-secretproviderclass.yaml
+++ b/test/bats/configs/vault-kv-secretproviderclass.yaml
@@ -15,6 +15,7 @@ spec:
       - objectName: "secret-1"
         secretPath: "secret/data/kv1"
         secretKey: "bar1"
+        filePermission: 0600
       - objectName: "secret-2"
         secretPath: "secret/data/kv2"
         secretKey: "bar2"

--- a/test/bats/provider.bats
+++ b/test/bats/provider.bats
@@ -140,8 +140,16 @@ teardown(){
     result=$(kubectl --namespace=test exec nginx-kv -- cat /mnt/secrets-store/secret-1)
     [[ "$result" == "hello1" ]]
 
+    # Check file permission is non-default
+    result=$(kubectl --namespace=test exec nginx-kv -- stat -c '%a' /mnt/secrets-store/..data/secret-1)
+    [[ "$result" == "600" ]]
+
     result=$(kubectl --namespace=test exec nginx-kv -- cat /mnt/secrets-store/secret-2)
     [[ "$result" == "hello2" ]]
+
+    # Check file permission is default
+    result=$(kubectl --namespace=test exec nginx-kv -- stat -c '%a' /mnt/secrets-store/..data/secret-2)
+    [[ "$result" == "644" ]]
 }
 
 @test "2 Sync with kubernetes secrets" {


### PR DESCRIPTION
Adds a new `filePermission` option in the SecretProviderClass parameters to set the permissions mounted files should be given. This was a feature brought up in the most recent community call, and is particularly helpful for secrets like private keys, where tooling will reject or print warnings when their permissions are too open.