### PR TITLE
feat: allow customizing the "aud" claim in the JWT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ IMPROVEMENTS:
   * `-vault-tls-client-cert`
   * `-vault-tls-client-key`
   * `-vault-tls-skip-verify`
+* Add an optional SecretProviderClass parameter `audience` to customize the `aud` claim in the JWT [[GH-144](https://github.com/hashicorp/vault-csi-provider/pull/144)]
 
 ## 1.0.0 (January 25th, 2022)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,7 @@ type Parameters struct {
 	VaultTLSConfig           api.TLSConfig
 	Secrets                  []Secret
 	PodInfo                  PodInfo
+	Audience                 string
 }
 
 type PodInfo struct {
@@ -128,6 +129,7 @@ func parseParameters(parametersStr string) (Parameters, error) {
 	parameters.PodInfo.UID = types.UID(params["csi.storage.k8s.io/pod.uid"])
 	parameters.PodInfo.Namespace = params["csi.storage.k8s.io/pod.namespace"]
 	parameters.PodInfo.ServiceAccountName = params["csi.storage.k8s.io/serviceAccount.name"]
+	parameters.Audience = params["audience"]
 	if skipTLS, ok := params["vaultSkipTLSVerify"]; ok {
 		value, err := strconv.ParseBool(skipTLS)
 		if err == nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -101,6 +101,7 @@ func TestParseParameters(t *testing.T) {
 			Namespace:          "test",
 			ServiceAccountName: "default",
 		},
+		Audience: "testaudience",
 	}
 	require.Equal(t, expected, actual)
 }
@@ -155,6 +156,7 @@ func TestParseConfig(t *testing.T) {
 				"csi.storage.k8s.io/pod.namespace":       "my-pod-namespace",
 				"csi.storage.k8s.io/serviceAccount.name": "my-pod-sa-name",
 				"objects":                                objects,
+				"audience":                               "my-aud",
 			},
 			expected: Config{
 				TargetPath:     targetPath,
@@ -181,6 +183,7 @@ func TestParseConfig(t *testing.T) {
 						"my-pod-namespace",
 						"my-pod-sa-name",
 					},
+					Audience: "my-aud",
 				},
 			},
 		},

--- a/internal/config/testdata/example-parameters-string.txt
+++ b/internal/config/testdata/example-parameters-string.txt
@@ -6,5 +6,6 @@
     "objects":"- secretPath: \"v1/secret/foo1\"\n  objectName: \"bar1\"\n  method: \"GET\"\n- secretPath: \"v1/secret/foo2\"\n  objectName: \"bar2\"",
     "roleName":"example-role",
     "vaultAddress":"http://vault:8200",
-    "vaultSkipTLSVerify":"true"
+    "vaultSkipTLSVerify":"true",
+    "audience":"testaudience"
 }

--- a/test/bats/configs/vault-kv-custom-audience-secretproviderclass.yaml
+++ b/test/bats/configs/vault-kv-custom-audience-secretproviderclass.yaml
@@ -1,0 +1,15 @@
+# Use a custom audience
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: vault-kv-custom-audience
+spec:
+  provider: vault
+  parameters:
+    audience: custom-audience
+    roleName: "kv-custom-audience-role"
+    objects: |
+      - objectName: "secret"
+        secretPath: "secret/data/kv-custom-audience"
+        secretKey: "bar"
+

--- a/test/bats/configs/vault-policy-kv-custom-audience.hcl
+++ b/test/bats/configs/vault-policy-kv-custom-audience.hcl
@@ -1,0 +1,3 @@
+path "secret/data/kv-custom-audience" {
+  capabilities = ["read"]
+}


### PR DESCRIPTION
Allow optionally specifying the audience in the SecretProviderClass to allow a safe usage of the ["audience" parameter in the Vault Kubernetes auth method](https://www.vaultproject.io/api-docs/auth/kubernetes#:~:text=audience%20(string%3A%20%22%22)%20%2D%20Optional%20Audience%20claim%20to%20verify%20in%20the%20JWT.).
If a custom audience is specified, it is required to use as reviewer JWT in Vault something different from [the client JWT](https://www.vaultproject.io/docs/auth/kubernetes#use-the-vault-client-s-jwt-as-the-reviewer-jwt).

This PR was tested against GKE, using a [static token as reviewer JWT](https://www.vaultproject.io/docs/auth/kubernetes#continue-using-long-lived-tokens).

Example usage:
```yaml
apiVersion: secrets-store.csi.x-k8s.io/v1
kind: SecretProviderClass
metadata:
  name: vault-credentials-class
spec:
  provider: vault
  parameters:
    audience: my-custom-audience # <-- this is added by this PR
    roleName: my-kubernetes-role
    objects: |
      - objectName: "testSecret"
        secretPath: "kv/data/secretPath"
        secretKey: "secretKey"
```

TODO:
- [x] Update the CHANGELOG
- [ ] Update the [documentation pages](https://www.vaultproject.io/docs/platform/k8s/csi)