### PR TITLE
Unset -vault-addr flag default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGES:
 
 * Duplicate object names now trigger an error instead of silently overwriting files. [[GH-148](https://github.com/hashicorp/vault-csi-provider/pull/148)]
 
+BUGS:
+
+* `VAULT_ADDR` environment variable can now be used to set the Vault address. [[GH-160](https://github.com/hashicorp/vault-csi-provider/pull/160)]
+
 IMPROVEMENTS:
 
 * Secret versions are now reported as a hash of their input and contents instead of hardcoded to 0. [[GH-148](https://github.com/hashicorp/vault-csi-provider/pull/148)]

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func realMain(logger hclog.Logger) error {
 	flag.BoolVar(&flags.Version, "version", false, "Prints the version information.")
 	flag.StringVar(&flags.HealthAddr, "health-addr", ":8080", "Configure http listener for reporting health.")
 
-	flag.StringVar(&flags.VaultAddr, "vault-addr", "https://127.0.0.1:8200", "Default address for connecting to Vault. Can also be specified via the VAULT_ADDR environment variable.")
+	flag.StringVar(&flags.VaultAddr, "vault-addr", "", "Default address for connecting to Vault. Can also be specified via the VAULT_ADDR environment variable.")
 	flag.StringVar(&flags.VaultMount, "vault-mount", "kubernetes", "Default Vault mount path for Kubernetes authentication.")
 	flag.StringVar(&flags.VaultNamespace, "vault-namespace", "", "Default Vault namespace for Vault requests. Can also be specified via the VAULT_NAMESPACE environment variable.")
 


### PR DESCRIPTION
Goes hand-in-hand with https://github.com/hashicorp/vault-helm/pull/745.

This doesn't actually change the default, as it was already set to the same default as set in the [`api` package](https://github.com/hashicorp/vault/blob/f4f1646fe3f7fbed8b1173630bc6a51d96d09599/api/client.go#L220). It does, however, allow the `VAULT_ADDR` environment variable to have an effect.