### PR TITLE
Ensure we check for the key to exist before attempting to read it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGES:
 BUGS:
 
 * `VAULT_ADDR` environment variable can now be used to set the Vault address. [[GH-160](https://github.com/hashicorp/vault-csi-provider/pull/160)]
+* Secret mounting correctly fails now if the secret path exists but the requested secret key does not. [[GH-165](https://github.com/hashicorp/vault-csi-provider/issues/165)]
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGES:
 BUGS:
 
 * `VAULT_ADDR` environment variable can now be used to set the Vault address. [[GH-160](https://github.com/hashicorp/vault-csi-provider/pull/160)]
-* Secret mounting correctly fails now if the secret path exists but the requested secret key does not. [[GH-165](https://github.com/hashicorp/vault-csi-provider/issues/165)]
+* Secret mounting correctly fails now if the secret path exists but the requested secret key does not. [[GH-166](https://github.com/hashicorp/vault-csi-provider/issues/166)]
 
 IMPROVEMENTS:
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -225,7 +225,12 @@ func (p *provider) getSecret(ctx context.Context, client *api.Client, secretConf
 		return content, nil
 	}
 
-	return keyFromData(secret.Data, secretConfig.SecretKey)
+	value, err := keyFromData(secret.Data, secretConfig.SecretKey)
+	if err != nil {
+		return nil, fmt.Errorf("{%s}: {%s}", secretConfig.SecretPath, err)
+	}
+
+	return value, nil
 }
 
 // MountSecretsStoreObjectContent mounts content of the vault object to target path

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -227,7 +227,7 @@ func (p *provider) getSecret(ctx context.Context, client *api.Client, secretConf
 
 	value, err := keyFromData(secret.Data, secretConfig.SecretKey)
 	if err != nil {
-		return nil, fmt.Errorf("{%s}: {%s}", secretConfig.SecretPath, err)
+		return nil, fmt.Errorf("{%s}: {%w}", secretConfig.SecretPath, err)
 	}
 
 	return value, nil

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -161,6 +161,11 @@ func keyFromData(rootData map[string]interface{}, secretKey string) ([]byte, err
 		data = rootData
 	}
 
+	// Fail early if a the key does not exist in the secret
+	if _, ok := data[secretKey]; !ok {
+		return nil, fmt.Errorf("key %q does not exist at the secret path", secretKey)
+	}
+
 	// Special-case the most common format of strings so the contents are
 	// returned plainly without quotes that json.Marshal would add.
 	if content, ok := data[secretKey].(string); ok {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -192,6 +192,48 @@ func TestKeyFromData(t *testing.T) {
 	}
 }
 
+func TestKeyFromDataMissingKey(t *testing.T) {
+	data := map[string]interface{}{
+		"foo": "bar",
+		"baz": "zap",
+	}
+	dataWithDataString := map[string]interface{}{
+		"foo":  "bar",
+		"baz":  "zap",
+		"data": "hello",
+	}
+	dataWithDataField := map[string]interface{}{
+		"data": map[string]interface{}{
+			"foo": "bar",
+			"baz": "zap",
+		},
+	}
+	for _, tc := range []struct {
+		name string
+		key  string
+		data map[string]interface{}
+	}{
+		{
+			name: "base case",
+			key:  "non-existing",
+			data: data,
+		},
+		{
+			name: "string data",
+			key:  "non-existing",
+			data: dataWithDataString,
+		},
+		{
+			name: "kv v2 embedded data field",
+			key:  "non-existing",
+			data: dataWithDataField,
+		},
+	} {
+		_, err := keyFromData(tc.data, tc.key)
+		require.Error(t, err)
+	}
+}
+
 func TestHandleMountRequest(t *testing.T) {
 	// SETUP
 	mockVaultServer := httptest.NewServer(http.HandlerFunc(mockVaultHandler()))


### PR DESCRIPTION
This PR fixed #165, ensuring we check for the key existence before we pass it into json.Marshal. 

`data[secretKey]` returns `nil` and `json.Marshal(nil)` hides the fact that the secretKey doesn't exist. 

```
➜ make test 
gotestsum --format=short-verbose 
PASS internal/version.TestGetVersion (0.00s)
PASS internal/version
PASS internal/config.TestParseParametersFromYaml (0.00s)
PASS internal/config.TestParseParameters (0.00s)
PASS internal/config.TestParseConfig (0.00s)
PASS internal/config.TestParseConfig_Errors (0.00s)
PASS internal/config.TestValidateConfig (0.00s)
PASS internal/config
PASS TestListen (0.00s)
PASS .
PASS internal/provider.TestEnsureV1Prefix (0.00s)
PASS internal/provider.TestGenerateRequest (0.00s)
PASS internal/provider.TestKeyFromData (0.00s)
PASS internal/provider.TestKeyFromDataMissingKey (0.00s)
PASS internal/provider.TestHandleMountRequest (0.12s)
PASS internal/provider
PASS internal/client.TestNew (1.81s)
PASS internal/client.TestConfigPrecedence (0.00s)
PASS internal/client.TestNew_Error (0.00s)
PASS internal/client
EMPTY internal/server

DONE 15 tests in 6.840s
```