### PR TITLE
Fix close transition for jira action

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -62,7 +62,7 @@ jobs:
       uses: atlassian/gajira-transition@v2.0.1
       with:
         issue: ${{ steps.search.outputs.issue }}
-        transition: Close
+        transition: Closed
 
     - name: Reopen ticket
       if: github.event.action == 'reopened' && steps.search.outputs.issue


### PR DESCRIPTION
Here's an example of a failed action: https://github.com/hashicorp/vault-csi-provider/runs/7695714775?check_suite_focus=true