### PR TITLE
Fix CRT action syntax for appending SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: get product version
         id: get-product-version
         run: |
-          VERSION="${{ github.event.inputs.version || '0.0.0-dev+' + github.sha }}"
+          VERSION="${{ github.event.inputs.version || format('0.0.0-dev+{0}', github.sha) }}"
           echo "Using version ${VERSION}"
           echo "::set-output name=product-version::${VERSION}"
   generate-metadata-file:


### PR DESCRIPTION
I'm not sure why, but the build action stopped running on #169 once it got closed and re-opened, so I missed that there was a syntax error here. Here's an example of it now working on this PR: https://github.com/hashicorp/vault-csi-provider/runs/7696116659?check_suite_focus=true