### PR TITLE
Publish future images to public ECR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,3 +115,4 @@ jobs:
           arch: ${{matrix.arch}}
           tags: |
             docker.io/hashicorp/${{env.repo}}:${{env.version}}
+            public.ecr.aws/hashicorp/${{env.repo}}:${{env.version}}


### PR DESCRIPTION
Future releases will be released to the public HashiCorp repositories on both Docker Hub and ECR

Closes #162