### PR TITLE
Updating the release slack channel

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -4,7 +4,7 @@ project "vault-csi-provider" {
   team = "vault"
   slack {
     // #vault-releases channel
-    notification_channel = "CRF6FFKEW"
+    notification_channel = "C03RXFX5M4L" // #feed-vault-releases
   }
   github {
     organization = "hashicorp"


### PR DESCRIPTION
Shifting release notifications to #feed-vault-releases

Related to https://github.com/hashicorp/vault/pull/16949