### PR TITLE
Support Encoding of Secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+CHANGES:
+
+* Support utf-8 (default), hex, and base64 encoded secrets
+
 ## 1.2.1 (November 21st, 2022)
 
 CHANGES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 CHANGES:
 
-* Support utf-8 (default), hex, and base64 encoded secrets
+* Support utf-8 (default), hex, and base64 encoded secrets [[GH-194](https://github.com/hashicorp/vault-csi-provider/pull/194)]
 
 ## 1.2.1 (November 21st, 2022)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,6 +90,7 @@ type Secret struct {
 	Method         string                 `yaml:"method,omitempty"`
 	SecretArgs     map[string]interface{} `yaml:"secretArgs,omitempty"`
 	FilePermission os.FileMode            `yaml:"filePermission,omitempty"`
+	Encoding       string                 `yaml:"encoding,omitempty"`
 }
 
 func Parse(parametersStr, targetPath, permissionStr string) (Config, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -96,8 +96,8 @@ func TestParseParameters(t *testing.T) {
 			Insecure: true,
 		},
 		Secrets: []Secret{
-			{"bar1", "v1/secret/foo1", "", http.MethodGet, nil, 0},
-			{"bar2", "v1/secret/foo2", "", "", nil, 0},
+			{"bar1", "v1/secret/foo1", "", http.MethodGet, nil, 0, ""},
+			{"bar2", "v1/secret/foo2", "", "", nil, 0, ""},
 		},
 		PodInfo: PodInfo{
 			Name:               "nginx-secrets-store-inline",
@@ -135,7 +135,7 @@ func TestParseConfig(t *testing.T) {
 					expected.VaultRoleName = roleName
 					expected.VaultTLSConfig.Insecure = true
 					expected.Secrets = []Secret{
-						{"bar1", "v1/secret/foo1", "", "", nil, 0o600},
+						{"bar1", "v1/secret/foo1", "", "", nil, 0o600, ""},
 					}
 					return expected
 				}(),
@@ -171,7 +171,7 @@ func TestParseConfig(t *testing.T) {
 					VaultNamespace:           "my-vault-namespace",
 					VaultKubernetesMountPath: "my-mount-path",
 					Secrets: []Secret{
-						{"bar1", "v1/secret/foo1", "", "", nil, 0o600},
+						{"bar1", "v1/secret/foo1", "", "", nil, 0o600, ""},
 					},
 					VaultTLSConfig: api.TLSConfig{
 						CACert:        "my-ca-cert-path",

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -194,7 +194,6 @@ func keyFromData(rootData map[string]interface{}, secretKey string) ([]byte, err
 }
 
 func decodeValue(data []byte, encoding string) ([]byte, error) {
-
 	if len(encoding) == 0 || strings.EqualFold(encoding, EncodingUtf8) {
 		return data, nil
 	} else if strings.EqualFold(encoding, EncodingBase64) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -48,6 +49,12 @@ type cacheKey struct {
 	secretPath string
 	method     string
 }
+
+const (
+	EncodingBase64 string = "base64"
+	EncodingHex    string = "hex"
+	EncodingUtf8   string = "utf-8"
+)
 
 func (p *provider) createJWTToken(ctx context.Context, podInfo config.PodInfo, audience string) (string, error) {
 	p.logger.Debug("creating service account token bound to pod",
@@ -186,6 +193,19 @@ func keyFromData(rootData map[string]interface{}, secretKey string) ([]byte, err
 	return nil, fmt.Errorf("failed to extract secret content as string or JSON from key %q", secretKey)
 }
 
+func decodeValue(data []byte, encoding string) ([]byte, error) {
+
+	if len(encoding) == 0 || strings.EqualFold(encoding, EncodingUtf8) {
+		return data, nil
+	} else if strings.EqualFold(encoding, EncodingBase64) {
+		return base64.StdEncoding.DecodeString(string(data))
+	} else if strings.EqualFold(encoding, EncodingHex) {
+		return hex.DecodeString(string(data))
+	}
+
+	return nil, fmt.Errorf("invalid encoding type. Should be utf-8, base64, or hex")
+}
+
 func (p *provider) getSecret(ctx context.Context, client *api.Client, secretConfig config.Secret) ([]byte, error) {
 	var secret *api.Secret
 	var cached bool
@@ -233,7 +253,12 @@ func (p *provider) getSecret(ctx context.Context, client *api.Client, secretConf
 		return nil, fmt.Errorf("{%s}: {%w}", secretConfig.SecretPath, err)
 	}
 
-	return value, nil
+	decodedVal, decodeErr := decodeValue(value, secretConfig.Encoding)
+	if decodeErr != nil {
+		return nil, fmt.Errorf("{%s}: {%w}", secretConfig.SecretPath, decodeErr)
+	}
+
+	return decodedVal, nil
 }
 
 // MountSecretsStoreObjectContent mounts content of the vault object to target path

--- a/test/bats/configs/vault-kv-sync-secretproviderclass.yaml
+++ b/test/bats/configs/vault-kv-sync-secretproviderclass.yaml
@@ -18,6 +18,8 @@ spec:
       key: pwd
     - objectName: secret-2
       key: username
+    - objectName: secret-3
+      key: username_b64
   parameters:
     roleName: "kv-role"
     vaultAddress: https://vault:8200
@@ -31,3 +33,7 @@ spec:
       - objectName: "secret-2"
         secretPath: "v1/secret/data/kv-sync2"
         secretKey: "bar2"
+      - objectName: "secret-3"
+        secretPath: "/v1/secret/data/kv-sync3"
+        secretKey: "bar3"
+        encoding: "base64"

--- a/test/bats/provider.bats
+++ b/test/bats/provider.bats
@@ -88,6 +88,7 @@ setup(){
     kubectl --namespace=csi exec vault-0 -- vault kv put secret/kv2 bar2=hello2
     kubectl --namespace=csi exec vault-0 -- vault kv put secret/kv-sync1 bar1=hello-sync1
     kubectl --namespace=csi exec vault-0 -- vault kv put secret/kv-sync2 bar2=hello-sync2
+    kubectl --namespace=csi exec vault-0 -- vault kv put secret/kv-sync3 bar3=aGVsbG8tc3luYzM=
     kubectl --namespace=csi exec vault-0 -- vault secrets enable -namespace=acceptance -path=secret -version=2 kv
     kubectl --namespace=csi exec vault-0 -- vault kv put -namespace=acceptance secret/kv1-namespace greeting=hello-namespaces
     kubectl --namespace=csi exec vault-0 -- vault kv put secret/kv-custom-audience bar=hello-custom-audience
@@ -135,6 +136,7 @@ teardown(){
     kubectl --namespace=csi exec vault-0 -- vault kv delete secret/kv-custom-audience
     kubectl --namespace=csi exec vault-0 -- vault kv delete secret/kv-sync1
     kubectl --namespace=csi exec vault-0 -- vault kv delete secret/kv-sync2
+    kubectl --namespace=csi exec vault-0 -- vault kv delete secret/kv-sync3
 
     # Teardown shared k8s resources.
     kubectl delete --ignore-not-found namespace test
@@ -184,6 +186,9 @@ teardown(){
 
     result=$(kubectl --namespace=test exec $POD -- printenv | grep SECRET_USERNAME | awk -F"=" '{ print $2 }' | tr -d '\r\n')
     [[ "$result" == "hello-sync2" ]]
+
+    result=$(kubectl --namespace=test get secret kvsecret -o jsonpath="{.data.username_b64}" | base64 -d)
+    [[ "$result" == "hello-sync3" ]]
 
     result=$(kubectl --namespace=test get secret kvsecret -o jsonpath="{.metadata.labels.environment}")
     [[ "${result//$'\r'}" == "test" ]]


### PR DESCRIPTION
Added support for encoded secrets (#106). This makes sense e.g. in the context of non-UTF-8 encoded certificates, like pfx.
This would allow storing e.g. 
* asymmetric private/public key pairs for Pulsar
* certificates for Elasticsearch

as base64 encoded strings in Vault.

Since this is my first go with go (pun intended) I would appreciate any feedback.