### PR TITLE
Update integration tests to use latest Vault

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 name: build
+run-name: v${{ inputs.version }} release
 
 on:
   push:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -99,5 +99,5 @@ jobs:
 
       - name: bats tests
         env:
-          VAULT_LICENSE: "{{ secrets.VAULT_LICENSE_CI }}"
+          VAULT_LICENSE: "${{ secrets.VAULT_LICENSE_CI }}"
         run: DISPLAY_SETUP_TEARDOWN_LOGS=true make e2e-teardown e2e-setup e2e-test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -98,4 +98,6 @@ jobs:
         run: docker image load --input ${{ env.TARBALL_FILE }}
 
       - name: bats tests
+        env:
+          VAULT_LICENSE: "{{ secrets.VAULT_LICENSE_CI }}"
         run: DISPLAY_SETUP_TEARDOWN_LOGS=true make e2e-teardown e2e-setup e2e-test

--- a/test/bats/configs/vault/vault.values.yaml
+++ b/test/bats/configs/vault/vault.values.yaml
@@ -10,8 +10,7 @@ injector:
 
 server:
   image:
-    repository: docker.mirror.hashicorp.services/hashicorp/vault-enterprise
-    tag: 1.7.0_ent
+    repository: docker.mirror.hashicorp.services/hashicorp/vault
   volumes:
   - name: vault-server-tls
     secret:

--- a/test/bats/provider.bats
+++ b/test/bats/provider.bats
@@ -26,11 +26,6 @@ setup(){
 
     # 1. b) Setup kubernetes auth engine.
     kubectl --namespace=csi exec vault-0 -- vault auth enable kubernetes
-    # `issuer` argument corresponds to value of --service-account-issuer for kube-apiserver,
-    # and for this test assumes the default value that kind sets.
-    # For EKS: https://oidc.eks.<region>.amazonaws.com/id/<ID> (same as OpenID Connect provider URL)
-    # For AKS: "<dns-prefix>.hcp.<region>.azmk8s.io" (same as API server address, but with quotes)
-    # For GKE: https://container.googleapis.com/v1/projects/<project>/locations/<az|region>/clusters/<cluster-name>
     kubectl --namespace=csi exec vault-0 -- sh -c 'vault write auth/kubernetes/config \
         kubernetes_host="https://$KUBERNETES_PORT_443_TCP_ADDR:443"'
     if [ -n "${VAULT_LICENSE}" ]; then


### PR DESCRIPTION
The integration tests were still using a very old version of Vault Enterprise that allowed users to run it for a limited time without a license. Added a license to the repo so we can test a newer version of Vault, and also added some conditionals so that OSS users can run most of the tests themselves without requiring a license.