### PR TITLE
Support JWT auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 CHANGES:
 
-* SecretProviderClass objects now also accept `spec.parameters.vaultAuthMountPath` as an alternative to `spec.parameters.vaultKubernetesMountPath`. [[GH-209](https://github.com/hashicorp/vault-csi-provider/pull/209)]
+* SecretProviderClass objects now also accept `spec.parameters.vaultAuthMountPath` as an alternative to `spec.parameters.vaultKubernetesMountPath`. [[GH-210](https://github.com/hashicorp/vault-csi-provider/pull/210)]
 
 FEATURES:
 
 * The Provider will cache a Vault token per requesting pod in memory and re-use it until it expires. [[GH-202](https://github.com/hashicorp/vault-csi-provider/pull/202)]
-* JWT auth is supported by setting role name and auth mount path in the same way as for Kubernetes auth. [[GH-209](https://github.com/hashicorp/vault-csi-provider/pull/209)]
+* JWT auth is supported by setting role name and auth mount path in the same way as for Kubernetes auth. [[GH-210](https://github.com/hashicorp/vault-csi-provider/pull/210)]
 
 ## 1.3.0 (April 5th, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 ## Unreleased
 
+CHANGES:
+
+* SecretProviderClass objects now also accept `spec.parameters.vaultAuthMountPath` as an alternative to `spec.parameters.vaultKubernetesMountPath`. [[GH-209](https://github.com/hashicorp/vault-csi-provider/pull/209)]
+
 FEATURES:
 
 * The Provider will cache a Vault token per requesting pod in memory and re-use it until it expires. [[GH-202](https://github.com/hashicorp/vault-csi-provider/pull/202)]
+* JWT auth is supported by setting role name and auth mount path in the same way as for Kubernetes auth. [[GH-209](https://github.com/hashicorp/vault-csi-provider/pull/209)]
 
 ## 1.3.0 (April 5th, 2023)
 

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ setup-kind:
 
 e2e-setup:
 	kind load docker-image e2e/vault-csi-provider:latest
-	kubectl create namespace csi
+	kubectl apply -f test/bats/configs/cluster-resources.yaml
 	helm install secrets-store-csi-driver secrets-store-csi-driver \
 		--repo https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts --version=$(CSI_DRIVER_VERSION) \
 		--wait --timeout=5m \
@@ -105,7 +105,7 @@ e2e-teardown:
 	helm uninstall --namespace=csi vault || true
 	helm uninstall --namespace=csi vault-bootstrap || true
 	helm uninstall --namespace=csi secrets-store-csi-driver || true
-	kubectl delete --ignore-not-found namespace csi
+	kubectl delete --ignore-not-found -f test/bats/configs/cluster-resources.yaml
 
 e2e-test:
 	bats test/bats/provider.bats

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -80,7 +80,7 @@ func overlayConfig(cfg *api.Config, vaultAddr string, tlsConfig api.TLSConfig) e
 // We follow this pattern because we assume Vault Agent is caching and renewing
 // our auth token, and we have no universal way to check it's still valid and
 // in the Agent's cache before making a request.
-func (c *Client) RequestSecret(ctx context.Context, authMethod *auth.KubernetesAuth, secretConfig config.Secret) (*api.Secret, error) {
+func (c *Client) RequestSecret(ctx context.Context, authMethod *auth.KubernetesJWTAuth, secretConfig config.Secret) (*api.Secret, error) {
 	// Ensure we have a token available.
 	authed, err := c.auth(ctx, authMethod, "")
 	if err != nil {
@@ -125,7 +125,7 @@ func (c *Client) RequestSecret(ctx context.Context, authMethod *auth.KubernetesA
 // authentications so that when a token expires, multiple consumers asking it
 // to reauthenticate at the same time only trigger one new authentication with
 // Vault.
-func (c *Client) auth(ctx context.Context, authMethod *auth.KubernetesAuth, failedToken string) (authed bool, err error) {
+func (c *Client) auth(ctx context.Context, authMethod *auth.KubernetesJWTAuth, failedToken string) (authed bool, err error) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -117,7 +117,7 @@ func TestRequestSecret_OnlyAuthenticatesOnce(t *testing.T) {
 	k8sClient := fake.NewSimpleClientset(
 		&corev1.ServiceAccount{},
 	)
-	authMethod := auth.NewKubernetesAuth(hclog.Default(), k8sClient, config.Parameters{}, "")
+	authMethod := auth.NewKubernetesJWTAuth(hclog.Default(), k8sClient, config.Parameters{}, "")
 	client, err := New(hclog.Default(), config.Parameters{}, flagsConfig)
 	require.NoError(t, err)
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -30,12 +30,12 @@ type provider struct {
 	vaultResponseCache map[vaultResponseCacheKey]*api.Secret
 
 	// Allows mocking Kubernetes API for tests.
-	authMethod    *auth.KubernetesAuth
+	authMethod    *auth.KubernetesJWTAuth
 	hmacGenerator *hmacgen.HMACGenerator
 	clientCache   *clientcache.ClientCache
 }
 
-func NewProvider(logger hclog.Logger, authMethod *auth.KubernetesAuth, hmacGenerator *hmacgen.HMACGenerator, clientCache *clientcache.ClientCache) *provider {
+func NewProvider(logger hclog.Logger, authMethod *auth.KubernetesJWTAuth, hmacGenerator *hmacgen.HMACGenerator, clientCache *clientcache.ClientCache) *provider {
 	p := &provider{
 		logger:             logger,
 		vaultResponseCache: make(map[vaultResponseCacheKey]*api.Secret),

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -231,7 +231,7 @@ func TestHandleMountRequest(t *testing.T) {
 	k8sClient := fake.NewSimpleClientset(
 		&corev1.ServiceAccount{},
 	)
-	authMethod := auth.NewKubernetesAuth(hclog.Default(), k8sClient, spcConfig.Parameters, "")
+	authMethod := auth.NewKubernetesJWTAuth(hclog.Default(), k8sClient, spcConfig.Parameters, "")
 	hmacGenerator := hmac.NewHMACGenerator(k8sClient, &corev1.Secret{})
 	clientCache, err := clientcache.NewClientCache(hclog.Default(), 10)
 	require.NoError(t, err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -53,7 +53,7 @@ func (s *Server) Mount(ctx context.Context, req *pb.MountRequest) (*pb.MountResp
 		return nil, err
 	}
 
-	authMethod := auth.NewKubernetesAuth(s.logger.Named("auth"), s.k8sClient, cfg.Parameters, s.flagsConfig.VaultMount)
+	authMethod := auth.NewKubernetesJWTAuth(s.logger.Named("auth"), s.k8sClient, cfg.Parameters, s.flagsConfig.VaultMount)
 	provider := provider.NewProvider(s.logger.Named("provider"), authMethod, s.hmacGenerator, s.clientCache)
 	resp, err := provider.HandleMountRequest(ctx, cfg, s.flagsConfig)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func realMain(logger hclog.Logger) error {
 	flag.IntVar(&flags.CacheSize, "cache-size", 1000, "Set the maximum number of Vault tokens that will be cached in-memory. One Vault token will be stored for each pod on the same node that mounts secrets.")
 
 	flag.StringVar(&flags.VaultAddr, "vault-addr", "", "Default address for connecting to Vault. Can also be specified via the VAULT_ADDR environment variable.")
-	flag.StringVar(&flags.VaultMount, "vault-mount", "kubernetes", "Default Vault mount path for Kubernetes authentication.")
+	flag.StringVar(&flags.VaultMount, "vault-mount", "kubernetes", "Default Vault mount path for authentication. Can refer to a Kubernetes or JWT auth mount.")
 	flag.StringVar(&flags.VaultNamespace, "vault-namespace", "", "Default Vault namespace for Vault requests. Can also be specified via the VAULT_NAMESPACE environment variable.")
 
 	flag.StringVar(&flags.TLSCACertPath, "vault-tls-ca-cert", "", "Path on disk to a single PEM-encoded CA certificate to trust for Vault. Takes precendence over -vault-tls-ca-directory. Can also be specified via the VAULT_CACERT environment variable.")

--- a/test/bats/configs/cluster-resources.yaml
+++ b/test/bats/configs/cluster-resources.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 ---
 apiVersion: v1
 kind: Namespace

--- a/test/bats/configs/cluster-resources.yaml
+++ b/test/bats/configs/cluster-resources.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: csi
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: oidc-reviewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:service-account-issuer-discovery
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:unauthenticated

--- a/test/bats/configs/vault-kv-secretproviderclass-jwt-auth.yaml
+++ b/test/bats/configs/vault-kv-secretproviderclass-jwt-auth.yaml
@@ -5,7 +5,7 @@
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
-  name: vault-kv
+  name: vault-kv-jwt-auth
 spec:
   provider: vault
   parameters:

--- a/test/bats/configs/vault-kv-secretproviderclass-jwt-auth.yaml
+++ b/test/bats/configs/vault-kv-secretproviderclass-jwt-auth.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# The "Hello World" Vault SecretProviderClass
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: vault-kv
+spec:
+  provider: vault
+  parameters:
+    roleName: "jwt-kv-role"
+    vaultAuthMountPath: "jwt"
+    objects: |
+      - objectName: "secret-1"
+        secretPath: "secret/data/kv1"
+        secretKey: "bar1"
+        filePermission: 0600

--- a/test/bats/provider.bats
+++ b/test/bats/provider.bats
@@ -144,6 +144,7 @@ teardown(){
         kubectl --namespace=csi exec vault-0 -- vault namespace delete acceptance
     fi
     kubectl --namespace=csi exec vault-0 -- vault auth disable kubernetes
+    kubectl --namespace=csi exec vault-0 -- vault auth disable jwt
     kubectl --namespace=csi exec vault-0 -- vault secrets disable secret
     kubectl --namespace=csi exec vault-0 -- vault secrets disable pki
     kubectl --namespace=csi exec vault-0 -- vault secrets disable database

--- a/test/bats/provider.bats
+++ b/test/bats/provider.bats
@@ -115,6 +115,7 @@ setup(){
     kubectl --namespace=test apply -f $CONFIGS/vault-kv-custom-audience-secretproviderclass.yaml
     kubectl --namespace=test apply -f $CONFIGS/vault-kv-namespace-secretproviderclass.yaml
     kubectl --namespace=test apply -f $CONFIGS/vault-kv-secretproviderclass.yaml
+    kubectl --namespace=test apply -f $CONFIGS/vault-kv-secretproviderclass-jwt-auth.yaml
     kubectl --namespace=test apply -f $CONFIGS/vault-kv-sync-secretproviderclass.yaml
     kubectl --namespace=test apply -f $CONFIGS/vault-kv-sync-multiple-secretproviderclass.yaml
     kubectl --namespace=test apply -f $CONFIGS/vault-pki-secretproviderclass.yaml
@@ -403,9 +404,9 @@ teardown(){
 
 @test "12 JWT auth" {
     helm --namespace=test install nginx $CONFIGS/nginx \
-        --set engine=kv --set sa=kv \
+        --set engine=kv-jwt-auth --set sa=kv \
         --wait --timeout=5m
 
-    result=$(kubectl --namespace=test exec nginx-kv -- cat /mnt/secrets-store/secret-1)
+    result=$(kubectl --namespace=test exec nginx-kv-jwt-auth -- cat /mnt/secrets-store/secret-1)
     [[ "$result" == "hello1" ]]
 }


### PR DESCRIPTION
Someone pointed out that JWT auth already works because the login endpoints are identical for [kubernetes](https://developer.hashicorp.com/vault/api-docs/auth/kubernetes#login) and [JWT](https://developer.hashicorp.com/vault/api-docs/auth/jwt#jwt-login). This just improves the naming and adds an integration test for the purpose of regression testing so that we can officially document JWT auth as supported.