### PR TITLE
Prepare 1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+# 1.4.0 (April 28th, 2023)
+
 CHANGES:
 
 * SecretProviderClass objects now also accept `spec.parameters.vaultAuthMountPath` as an alternative to `spec.parameters.vaultKubernetesMountPath`. [[GH-210](https://github.com/hashicorp/vault-csi-provider/pull/210)]

--- a/README.md
+++ b/README.md
@@ -7,11 +7,8 @@ Vault and use the Secrets Store CSI driver interface to mount them into Kubernet
 
 ### Prerequisites
 
-* Kubernetes 1.16+ for both the master and worker nodes (Linux-only)
+* Supported Kubernetes version, see the [documentation](https://developer.hashicorp.com/vault/docs/platform/k8s/csi#supported-kubernetes-versions) (runs on Linux nodes only)
 * [Secrets store CSI driver](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html) installed
-* `TokenRequest` endpoint available, which requires setting the flags
-  `--service-account-signing-key-file` and `--service-account-issuer` for
-  `kube-apiserver`. Set by default from 1.20+ and earlier in most managed services.
 
 ### Using helm
 

--- a/deployment/vault-csi-provider.yaml
+++ b/deployment/vault-csi-provider.yaml
@@ -88,7 +88,7 @@ spec:
       tolerations:
       containers:
         - name: provider-vault-installer
-          image: hashicorp/vault-csi-provider:1.3.0
+          image: hashicorp/vault-csi-provider:1.4.0
           imagePullPolicy: Always
           args:
             - -endpoint=/provider/vault.sock

--- a/manifest_staging/deployment/vault-csi-provider.yaml
+++ b/manifest_staging/deployment/vault-csi-provider.yaml
@@ -88,7 +88,7 @@ spec:
       tolerations:
       containers:
         - name: provider-vault-installer
-          image: hashicorp/vault-csi-provider:1.3.0
+          image: hashicorp/vault-csi-provider:1.4.0
           imagePullPolicy: Always
           args:
             - -endpoint=/provider/vault.sock


### PR DESCRIPTION
## Changes

* SecretProviderClass objects now also accept `spec.parameters.vaultAuthMountPath` as an alternative to `spec.parameters.vaultKubernetesMountPath`. [[GH-210](https://github.com/hashicorp/vault-csi-provider/pull/210)]

## Features

* The Provider will cache a Vault token per requesting pod in memory and re-use it until it expires. [[GH-202](https://github.com/hashicorp/vault-csi-provider/pull/202)]
* JWT auth is supported by setting role name and auth mount path in the same way as for Kubernetes auth. [[GH-210](https://github.com/hashicorp/vault-csi-provider/pull/210)]