### PR TITLE
Revert name of build.yml jobs to default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,4 @@
 name: build
-run-name: Build v${{ inputs.version || format('0.0.0-dev+{0}', github.sha) }}
 
 on:
   push:


### PR DESCRIPTION
It looks like updating the run name might be what broke CRT release automation.