### PR TITLE
feat(logging): Add json logging configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,8 @@ type FlagsConfig struct {
 	TLSClientCert  string
 	TLSClientKey   string
 	TLSSkipVerify  bool
+
+	LogFormat string
 }
 
 func (fc FlagsConfig) TLSConfig() api.TLSConfig {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,8 +5,8 @@ package config
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -85,7 +85,7 @@ func TestParseParametersFromYaml(t *testing.T) {
 
 func TestParseParameters(t *testing.T) {
 	// This file's contents are copied directly from a driver mount request.
-	parametersStr, err := ioutil.ReadFile(filepath.Join("testdata", "example-parameters-string.txt"))
+	parametersStr, err := os.ReadFile(filepath.Join("testdata", "example-parameters-string.txt"))
 	require.NoError(t, err)
 	actual, err := parseParameters(string(parametersStr))
 	require.NoError(t, err)


### PR DESCRIPTION
Closes #177 

Added json logging flag to allow logging in JSON format. Flags set to match Vaults flag `-log-format` and to support the same value `json`.
