### PR TITLE
Test against k8s 1.29

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind-k8s-version: [1.24.17, 1.25.16, 1.26.14, 1.27.11, 1.28.7, 1.29.2]
+        kind-k8s-version: [1.25.16, 1.26.14, 1.27.11, 1.28.7, 1.29.2]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind-k8s-version: [1.24.15, 1.25.11, 1.26.6, 1.27.3, 1.28.0]
+        kind-k8s-version: [1.24.17, 1.25.16, 1.26.14, 1.27.11, 1.28.7, 1.29.2]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0


### PR DESCRIPTION
- Add k8s 1.29.2 to the k8s version test matrix. 
- Bump all previous minor versions.