### PR TITLE
Update csi driver and vault-helm versions in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,16 +15,17 @@ PKG=github.com/hashicorp/vault-csi-provider/internal/version
 LDFLAGS?="-X '$(PKG).BuildVersion=$(VERSION)' \
 	-X '$(PKG).BuildDate=$(BUILD_DATE)' \
 	-X '$(PKG).GoVersion=$(shell go version)'"
-CSI_DRIVER_VERSION=1.3.4
-VAULT_HELM_VERSION=0.25.0
+CSI_DRIVER_VERSION=1.4.2
+VAULT_HELM_VERSION=0.27.0
 VAULT_VERSION=1.15.6
 GOLANGCI_LINT_FORMAT?=colored-line-number
 
-VAULT_VERSION_ARGS=--set server.image.tag=$(VAULT_VERSION)
+VAULT_VERSION_ARGS=--set server.image.tag=$(VAULT_VERSION) --set csi.agent.image.tag=$(VAULT_VERSION)
 ifdef VAULT_LICENSE
 	VAULT_VERSION_ARGS=--set server.image.repository=docker.mirror.hashicorp.services/hashicorp/vault-enterprise \
 		--set server.image.tag=$(VAULT_VERSION)-ent \
-		--set server.enterpriseLicense.secretName=vault-ent-license
+		--set server.enterpriseLicense.secretName=vault-ent-license \
+		--set csi.agent.image.tag=$(VAULT_VERSION)
 endif
 
 .PHONY: default build test bootstrap fmt lint image e2e-image e2e-setup e2e-teardown e2e-test mod setup-kind promote-staging-manifest copyright

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # HashiCorp Vault Provider for Secrets Store CSI Driver
 
+> :warning: **Please note**: We take Vault's security and our users' trust very seriously. If
+you believe you have found a security issue in Vault CSI Provider, _please responsibly disclose_
+by contacting us at [security@hashicorp.com](mailto:security@hashicorp.com).
+
 HashiCorp [Vault](https://vaultproject.io) provider for the [Secrets Store CSI driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver) allows you to get secrets stored in
 Vault and use the Secrets Store CSI driver interface to mount them into Kubernetes pods.
 

--- a/test/bats/configs/vault/vault.values.yaml
+++ b/test/bats/configs/vault/vault.values.yaml
@@ -82,3 +82,7 @@ csi:
   - name: metadata
     mountPath: "/var/run/metadata/kubernetes.io/pod"
     readOnly: true
+
+  agent:
+    image:
+      repository: "docker.mirror.hashicorp.services/hashicorp/vault"


### PR DESCRIPTION
Also sets the agent image for csi to match vault server in the e2e test setup, and adds the security disclosure blurb to the README.