### PR TITLE
Bump GH actions for node 16 obsolescence

### DIFF
--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -16,6 +16,9 @@ inputs:
   vault-license:
     description: 'Vault license to use for enterprise tests'
     required: true
+  kind-cluster-name:
+    description: 'Name of the kind cluster to create and test against'
+    default: 'kind'
 runs:
   using: "composite"
   steps:
@@ -31,10 +34,21 @@ runs:
     - name: Create Kind Cluster
       uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
       with:
-        cluster_name: kind
+        cluster_name: ${{ inputs.kind-cluster-name }}
         config: test/bats/configs/kind/config.yaml
         node_image: kindest/node:v${{ inputs.k8s-version }}
         version: ${{ env.KIND_VERSION }}
+
+    - name: Create kind export log root
+      id: create_kind_export_log_root
+      shell: bash
+      run: |
+        vault_flavor=ent
+        log_artifact_name="kind-${{ inputs.kind-cluster-name }}-$(git rev-parse --short ${{ github.sha }})-${{ inputs.k8s-version }}-${{ inputs.vault-version }}-${vault_flavor}-helm-logs"
+        log_root="/tmp/${log_artifact_name}"
+        mkdir -p "${log_root}"
+        echo "log_root=${log_root}" >> $GITHUB_OUTPUT
+        echo "log_artifact_name=${log_artifact_name}" >> $GITHUB_OUTPUT
 
     - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
       with:
@@ -49,3 +63,23 @@ runs:
       env:
         VAULT_LICENSE: ${{ inputs.vault-license }}
       run: make e2e-teardown e2e-setup e2e-test DISPLAY_SETUP_TEARDOWN_LOGS=true VAULT_VERSION="${{ inputs.vault-version }}"
+
+    - name: export kind cluster logs
+      if: always()
+      shell: bash
+      run: |
+        kind export logs --name ${{ inputs.kind-cluster-name }} ${{ steps.create_kind_export_log_root.outputs.log_root }}
+
+    - name: Store kind cluster logs
+      if: success()
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      with:
+        name: ${{ steps.create_kind_export_log_root.outputs.log_artifact_name }}
+        path: ${{ steps.create_kind_export_log_root.outputs.log_root }}
+
+    - name: Store kind cluster logs failure
+      if: failure()
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+      with:
+        name: ${{ steps.create_kind_export_log_root.outputs.log_artifact_name }}-failed
+        path: ${{ steps.create_kind_export_log_root.outputs.log_root }}

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
     - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
         node-version: ${{ env.NODE_VERSION }}
@@ -29,14 +29,14 @@ runs:
       shell: bash
 
     - name: Create Kind Cluster
-      uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
+      uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
       with:
         cluster_name: kind
         config: test/bats/configs/kind/config.yaml
         node_image: kindest/node:v${{ inputs.k8s-version }}
         version: ${{ env.KIND_VERSION }}
 
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+    - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
       with:
         name: vault-csi-provider-image
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: get product version
         id: get-product-version
         run: |
@@ -32,7 +32,7 @@ jobs:
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
     steps:
       - name: 'Checkout directory'
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Generate metadata file
         id: generate-metadata-file
         uses: hashicorp/actions-generate-metadata@v1
@@ -40,7 +40,7 @@ jobs:
           version: ${{ needs.get-product-version.outputs.product-version }}
           product: ${{ env.PKG_NAME }}
 
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
@@ -57,10 +57,10 @@ jobs:
     name: Go linux ${{ matrix.arch }} build
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Setup go
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version-file: .go-version
 
@@ -72,7 +72,7 @@ jobs:
           mkdir dist out
           make build
           zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip dist/
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip
           path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip
@@ -91,9 +91,9 @@ jobs:
       version: ${{needs.get-product-version.outputs.product-version}}
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Docker Build (Action)
-        uses: hashicorp/actions-docker-build@v1
+        uses: hashicorp/actions-docker-build@v2
         with:
           version: ${{env.version}}
           target: default

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,8 +25,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version-file: .go-version
 
@@ -41,8 +41,8 @@ jobs:
     outputs:
       TARBALL_FILE: ${{ env.TARBALL_FILE }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version-file: .go-version
 
@@ -54,7 +54,7 @@ jobs:
       - name: Test
         run: make test
 
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: vault-csi-provider-image
           path: ${{ env.TARBALL_FILE }}
@@ -74,7 +74,7 @@ jobs:
           k8s-version: ${{ fromJson(needs.versions.outputs.K8S_VERSIONS) }}
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: ./.github/actions/integration-test
         name: vault:${{ matrix.vault-version }} kind:${{ matrix.k8s-version }}
         with:
@@ -99,7 +99,7 @@ jobs:
             - ${{ needs.versions.outputs.VAULT_N_2 }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: ./.github/actions/integration-test
         name: vault:${{ matrix.vault-version }} kind:${{ matrix.k8s-version }}
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,9 +15,9 @@ jobs:
       - run: echo "setting versions"
     outputs:
       K8S_VERSIONS: '["1.29.2", "1.28.7", "1.27.11", "1.26.14", "1.25.16"]'
-      VAULT_N: "1.15.6"
-      VAULT_N_1: "1.14.10"
-      VAULT_N_2: "1.13.13"
+      VAULT_N: "1.16.2"
+      VAULT_N_1: "1.15.6"
+      VAULT_N_2: "1.14.10"
   copyright:
     uses: hashicorp/vault-workflows-common/.github/workflows/copyright-headers.yaml@main
   go-checks:


### PR DESCRIPTION
Other fixes
- store exported kind logs in GH which will make it easier to debug the CI tests
- test against vault 1.16.2
- update vault license