### PR TITLE
Test with latest chart and vault 1.17 versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       # JSON encoded array of k8s versions.
       K8S_VERSIONS: '["1.30.0", "1.29.4", "1.28.9", "1.27.13", "1.26.15"]'
-      VAULT_N: "1.17.1"
+      VAULT_N: "1.17.2"
       VAULT_N_1: "1.16.3"
       VAULT_N_2: "1.15.6"
   copyright:

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ LDFLAGS?="-X '$(PKG).BuildVersion=$(VERSION)' \
 	-X '$(PKG).BuildDate=$(BUILD_DATE)' \
 	-X '$(PKG).GoVersion=$(shell go version)'"
 CSI_DRIVER_VERSION=1.4.4
-VAULT_HELM_VERSION=0.28.0
-VAULT_VERSION=1.17.1
+VAULT_HELM_VERSION=0.28.1
+VAULT_VERSION=1.17.2
 GOLANGCI_LINT_FORMAT?=colored-line-number
 
 VAULT_VERSION_ARGS=--set server.image.tag=$(VAULT_VERSION) --set csi.agent.image.tag=$(VAULT_VERSION)


### PR DESCRIPTION
Use vault-helm v0.28.1 and Vault 1.17.2 in tests.