### PR TITLE
Vault 31629/bump k8s version

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
       - run: echo "setting versions"
     outputs:
       # JSON encoded array of k8s versions.
-      K8S_VERSIONS: '["1.30.0", "1.29.4", "1.28.9", "1.27.13", "1.26.15"]'
+      K8S_VERSIONS: '["1.31.2", "1.30.6", "1.29.10", "1.28.9", "1.27.13"]'
       VAULT_N: "1.17.3"
       VAULT_N_1: "1.16.3"
       VAULT_N_2: "1.15.6"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,7 @@ name: Tests
 on: [push, workflow_dispatch]
 
 env:
-  KIND_VERSION: "v0.23.0"
+  KIND_VERSION: "v0.25.0"
   BATS_VERSION: "1.11.0"
   NODE_VERSION: "19.8.1"
   TARBALL_FILE: vault-csi-provider.docker.tar
@@ -15,7 +15,7 @@ jobs:
       - run: echo "setting versions"
     outputs:
       # JSON encoded array of k8s versions.
-      K8S_VERSIONS: '["1.31.2", "1.30.6", "1.29.10", "1.28.9", "1.27.13"]'
+      K8S_VERSIONS: '["1.31.2", "1.30.6", "1.29.10", "1.28.15", "1.27.16"]'
       VAULT_N: "1.18.1"
       VAULT_N_1: "1.17.6"
       VAULT_N_2: "1.16.3"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,9 +16,9 @@ jobs:
     outputs:
       # JSON encoded array of k8s versions.
       K8S_VERSIONS: '["1.31.2", "1.30.6", "1.29.10", "1.28.9", "1.27.13"]'
-      VAULT_N: "1.17.3"
-      VAULT_N_1: "1.16.3"
-      VAULT_N_2: "1.15.6"
+      VAULT_N: "1.18.1"
+      VAULT_N_1: "1.17.6"
+      VAULT_N_2: "1.16.3"
   copyright:
     uses: hashicorp/vault-workflows-common/.github/workflows/copyright-headers.yaml@main
   go-checks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 CHANGES:
 
+* Test with K8s 1.27-1.31
 * Updated Docker base image from alpine 3.20.2 -> 3.20.3
 * Updated dependencies:
   * github.com/hashicorp/vault/api v1.14.0 -> v1.15.0

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ LDFLAGS?="-X '$(PKG).BuildVersion=$(VERSION)' \
 	-X '$(PKG).BuildDate=$(BUILD_DATE)' \
 	-X '$(PKG).GoVersion=$(shell go version)'"
 CSI_DRIVER_VERSION=1.4.4
-VAULT_HELM_VERSION=0.28.1
-VAULT_VERSION=1.17.2
+VAULT_HELM_VERSION=0.29.0
+VAULT_VERSION=1.18.1
 GOLANGCI_LINT_FORMAT?=colored-line-number
 
 VAULT_VERSION_ARGS=--set server.image.tag=$(VAULT_VERSION) --set csi.agent.image.tag=$(VAULT_VERSION)


### PR DESCRIPTION
Drop 1.26, add 1.31

Bump Vault versions