### PR TITLE
support setting a default audience

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -117,7 +117,7 @@ func TestRequestSecret_OnlyAuthenticatesOnce(t *testing.T) {
 	k8sClient := fake.NewSimpleClientset(
 		&corev1.ServiceAccount{},
 	)
-	authMethod := auth.NewKubernetesJWTAuth(hclog.Default(), k8sClient, config.Parameters{}, "")
+	authMethod := auth.NewKubernetesJWTAuth(hclog.Default(), k8sClient, config.Parameters{}, "", "")
 	client, err := New(hclog.Default(), config.Parameters{}, flagsConfig)
 	require.NoError(t, err)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,8 @@ type FlagsConfig struct {
 	VaultMount     string
 	VaultNamespace string
 
+	Audience string
+
 	TLSCACertPath  string
 	TLSCADirectory string
 	TLSServerName  string

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -231,7 +231,7 @@ func TestHandleMountRequest(t *testing.T) {
 	k8sClient := fake.NewSimpleClientset(
 		&corev1.ServiceAccount{},
 	)
-	authMethod := auth.NewKubernetesJWTAuth(hclog.Default(), k8sClient, spcConfig.Parameters, "")
+	authMethod := auth.NewKubernetesJWTAuth(hclog.Default(), k8sClient, spcConfig.Parameters, "", "")
 	hmacGenerator := hmac.NewHMACGenerator(k8sClient, &corev1.Secret{})
 	clientCache, err := clientcache.NewClientCache(hclog.Default(), 10)
 	require.NoError(t, err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -53,7 +53,7 @@ func (s *Server) Mount(ctx context.Context, req *pb.MountRequest) (*pb.MountResp
 		return nil, err
 	}
 
-	authMethod := auth.NewKubernetesJWTAuth(s.logger.Named("auth"), s.k8sClient, cfg.Parameters, s.flagsConfig.VaultMount)
+	authMethod := auth.NewKubernetesJWTAuth(s.logger.Named("auth"), s.k8sClient, cfg.Parameters, s.flagsConfig.VaultMount, s.flagsConfig.Audience)
 	provider := provider.NewProvider(s.logger.Named("provider"), authMethod, s.hmacGenerator, s.clientCache)
 	resp, err := provider.HandleMountRequest(ctx, cfg, s.flagsConfig)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -74,6 +74,8 @@ func realMain(logger hclog.Logger) error {
 	flag.StringVar(&flags.VaultMount, "vault-mount", "kubernetes", "Default Vault mount path for authentication. Can refer to a Kubernetes or JWT auth mount.")
 	flag.StringVar(&flags.VaultNamespace, "vault-namespace", "", "Default Vault namespace for Vault requests. Can also be specified via the VAULT_NAMESPACE environment variable.")
 
+	flag.StringVar(&flags.Audience, "audience", "", "Default audience when generating a service account token. If not set, the token audiences will default to the Kubernetes cluster's default API audiences.")
+
 	flag.StringVar(&flags.TLSCACertPath, "vault-tls-ca-cert", "", "Path on disk to a single PEM-encoded CA certificate to trust for Vault. Takes precendence over -vault-tls-ca-directory. Can also be specified via the VAULT_CACERT environment variable.")
 	flag.StringVar(&flags.TLSCADirectory, "vault-tls-ca-directory", "", "Path on disk to a directory of PEM-encoded CA certificates to trust for Vault. Can also be specified via the VAULT_CAPATH environment variable.")
 	flag.StringVar(&flags.TLSServerName, "vault-tls-server-name", "", "Name to use as the SNI host when connecting to Vault via TLS. Can also be specified via the VAULT_TLS_SERVER_NAME environment variable.")


### PR DESCRIPTION
Currently you can set a default `-vault-addr` and `-vault-mount` when running vault-csi-provider. This change also adds `-audience` so you can set a default audience for generated service account tokens. Otherwise, for environments that use a custom audience, it must be set in every SecretProviderClass. Since we can set a default for the mount path, it only makes sense to also be able to set a default for the audience.