### PR TITLE
renaming to "Vault Secrets Store CSI Provider"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,8 @@ CHANGES:
   * k8s.io/client-go v0.30.2 -> v0.30.3
   * golang.org/x/crypto v0.24.0 -> v0.26.0
   * golang.org/x/net v0.26.0 -> v0.28.0
-  * golang.org/x/sys v0.21.0 -> v0.23.0 
-  * golang.org/x/term v0.21.0 -> v0.23.0 
+  * golang.org/x/sys v0.21.0 -> v0.23.0
+  * golang.org/x/term v0.21.0 -> v0.23.0
   * golang.org/x/text v0.16.0 -> v0.17.0
 
 ## 1.4.3 (July 3rd, 2024)
@@ -133,14 +133,14 @@ FEATURES:
 
 CHANGES:
 
-* Vault CSI Provider will use service account tokens passed from the Secrets Store CSI Driver instead of generating one if an appropriate token is provided. [[GH-163](https://github.com/hashicorp/vault-csi-provider/pull/163)]
-  * The Secrets Store CSI driver needs to be configured to generate tokens with the correct audience for this feature. Vault CSI Provider
+* Vault Secrets Store CSI Provider will use service account tokens passed from the Secrets Store CSI Driver instead of generating one if an appropriate token is provided. [[GH-163](https://github.com/hashicorp/vault-csi-provider/pull/163)]
+  * The Secrets Store CSI driver needs to be configured to generate tokens with the correct audience for this feature. Vault Secrets Store CSI Provider
     will look for a token with the audience specified in the SecretProviderClass, or otherwise "vault". To configure the driver to generate
     a token with the correct audience, use the
     [`tokenRequests`](https://github.com/kubernetes-sigs/secrets-store-csi-driver/tree/main/charts/secrets-store-csi-driver#configuration)
     option from the _driver_ helm chart via the flag `--set tokenRequests[0].audience="vault"`. See
     [CSI TokenRequests documentation](https://kubernetes-csi.github.io/docs/token-requests.html) for further details.
-* Vault CSI Provider now creates a Kubernetes secret with an HMAC key to produce consistent hashes for secret versions. [[GH-198](https://github.com/hashicorp/vault-csi-provider/pull/198)]
+* Vault Secrets Store CSI Provider now creates a Kubernetes secret with an HMAC key to produce consistent hashes for secret versions. [[GH-198](https://github.com/hashicorp/vault-csi-provider/pull/198)]
   * Requires RBAC permissions to create secrets, and read the same specific secret back. Versions are not generated otherwise and a warning
     is logged on each mount that fails to generate a version.
   * Supports creating the secret with custom name via `-hmac-secret-name`

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ARG PRODUCT_NAME=vault-csi-provider
 ARG TARGETOS
 ARG TARGETARCH
 
-LABEL name="Vault CSI Provider" \
+LABEL name="Vault Secrets Store CSI Provider" \
       maintainer="Vault Team <vault@hashicorp.com>" \
       vendor="HashiCorp" \
       version=$PRODUCT_VERSION \
@@ -67,7 +67,7 @@ ARG PRODUCT_NAME=$BIN_NAME
 # TARGETARCH and TARGETOS are set automatically when --platform is provided.
 ARG TARGETOS TARGETARCH
 
-LABEL name="Vault CSI Provider" \
+LABEL name="Vault Secrets Store CSI Provider" \
       maintainer="Vault Team <vault@hashicorp.com>" \
       vendor="HashiCorp" \
       version=$PRODUCT_VERSION \

--- a/LICENSE
+++ b/LICENSE
@@ -4,41 +4,41 @@ License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
 Parameters
 
 Licensor:             HashiCorp, Inc.
-Licensed Work:        Vault CSI Provider Version 1.4.1 or later. 
+Licensed Work:        Vault Secrets Store CSI Provider Version 1.4.1 or later.
                       The Licensed Work is (c) 2024 HashiCorp, Inc.
 Additional Use Grant: You may make production use of the Licensed Work, provided
                       Your use does not include offering the Licensed Work to third
-                      parties on a hosted or embedded basis in order to compete with 
-                      HashiCorp's paid version(s) of the Licensed Work. For purposes 
+                      parties on a hosted or embedded basis in order to compete with
+                      HashiCorp's paid version(s) of the Licensed Work. For purposes
                       of this license:
 
                       A "competitive offering" is a Product that is offered to third
-                      parties on a paid basis, including through paid support 
-                      arrangements, that significantly overlaps with the capabilities 
-                      of HashiCorp's paid version(s) of the Licensed Work. If Your 
-                      Product is not a competitive offering when You first make it 
+                      parties on a paid basis, including through paid support
+                      arrangements, that significantly overlaps with the capabilities
+                      of HashiCorp's paid version(s) of the Licensed Work. If Your
+                      Product is not a competitive offering when You first make it
                       generally available, it will not become a competitive offering
-                      later due to HashiCorp releasing a new version of the Licensed 
-                      Work with additional capabilities. In addition, Products that 
+                      later due to HashiCorp releasing a new version of the Licensed
+                      Work with additional capabilities. In addition, Products that
                       are not provided on a paid basis are not competitive.
 
-                      "Product" means software that is offered to end users to manage 
-                      in their own environments or offered as a service on a hosted 
+                      "Product" means software that is offered to end users to manage
+                      in their own environments or offered as a service on a hosted
                       basis.
 
-                      "Embedded" means including the source code or executable code 
-                      from the Licensed Work in a competitive offering. "Embedded" 
-                      also means packaging the competitive offering in such a way 
-                      that the Licensed Work must be accessed or downloaded for the 
+                      "Embedded" means including the source code or executable code
+                      from the Licensed Work in a competitive offering. "Embedded"
+                      also means packaging the competitive offering in such a way
+                      that the Licensed Work must be accessed or downloaded for the
                       competitive offering to operate.
 
-                      Hosting or using the Licensed Work(s) for internal purposes 
-                      within an organization is not considered a competitive 
-                      offering. HashiCorp considers your organization to include all 
+                      Hosting or using the Licensed Work(s) for internal purposes
+                      within an organization is not considered a competitive
+                      offering. HashiCorp considers your organization to include all
                       of your affiliates under common control.
 
-                      For binding interpretive guidance on using HashiCorp products 
-                      under the Business Source License, please visit our FAQ. 
+                      For binding interpretive guidance on using HashiCorp products
+                      under the Business Source License, please visit our FAQ.
                       (https://www.hashicorp.com/license-faq)
 Change Date:          Four years from the date the Licensed Work is published.
 Change License:       MPL 2.0

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # HashiCorp Vault Provider for Secrets Store CSI Driver
 
-> :warning: **Please note**: We take Vault's security and our users' trust very seriously. If
-you believe you have found a security issue in Vault CSI Provider, _please responsibly disclose_
-by contacting us at [security@hashicorp.com](mailto:security@hashicorp.com).
+> :warning: **Please note**: We take Vault's security and our users' trust very
+seriously. If you believe you have found a security issue in Vault Secrets Store
+CSI Provider, _please responsibly disclose_ by contacting us at
+[security@hashicorp.com](mailto:security@hashicorp.com).
 
 HashiCorp [Vault](https://vaultproject.io) provider for the [Secrets Store CSI driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver) allows you to get secrets stored in
 Vault and use the Secrets Store CSI driver interface to mount them into Kubernetes pods.
@@ -20,8 +21,9 @@ The recommended installation method is via helm 3:
 
 ```bash
 helm repo add hashicorp https://helm.releases.hashicorp.com
-# Just installs Vault CSI provider. Adjust `server.enabled` and `injector.enabled`
-# if you also want helm to install Vault and the Vault Agent injector.
+# Just installs Vault Secrets Store CSI provider. Adjust `server.enabled` and
+# `injector.enabled` if you also want helm to install Vault and the Vault Agent
+# injector.
 helm install vault hashicorp/vault \
   --set "server.enabled=false" \
   --set "injector.enabled=false" \
@@ -40,24 +42,25 @@ kubectl apply -f deployment/vault-csi-provider.yaml
 
 See the [learn tutorial](https://learn.hashicorp.com/tutorials/vault/kubernetes-secret-store-driver)
 and [documentation pages](https://www.vaultproject.io/docs/platform/k8s/csi) for
-full details of deploying, configuring and using Vault CSI provider. The
-integration tests in [test/bats/provider.bats](./test/bats/provider.bats) also
+full details of deploying, configuring and using Vault Secrets Store CSI provider.
+The integration tests in [test/bats/provider.bats](./test/bats/provider.bats) also
 provide a good set of fully worked and tested examples to build on.
 
 ## Troubleshooting
 
-To troubleshoot issues with Vault CSI provider, look at logs from the Vault CSI
-provider pod running on the same node as your application pod:
+To troubleshoot issues with Vault Secrets Store CSI provider, look at logs from
+the Vault CSI provider pod running on the same node as your application pod:
 
   ```bash
   kubectl get pods -o wide
-  # find the Vault CSI provider pod running on the same node as your application pod
+  # find the Vault Secrets Store CSI provider pod running on the same node as
+  # your application pod
 
   kubectl logs vault-csi-provider-7x44t
   ```
 
 **Warning**
-The `-debug=true` flag has been deprecated, please use `-log-level=debug` instead. 
+The `-debug=true` flag has been deprecated, please use `-log-level=debug` instead.
 Available log levels are `info`, `debug`, `trace`, `warn`, `error`, and `off`.
 
 ## Developing


### PR DESCRIPTION
Renaming this project to "Vault Secrets Store CSI Provider".

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
