### PR TITLE
Updating Vault and vault-helm versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,10 +18,10 @@ jobs:
     outputs:
       # JSON encoded array of k8s versions.
       K8S_VERSIONS: '["1.33.4", "1.32.8", "1.31.12", "1.30.13", "1.29.14"]'
-      VAULT_N: "1.20.3"
-      VAULT_N_1: "1.19.9"
-      VAULT_N_2: "1.18.14"
-      VAULT_LTS_1: "1.16.25"
+      VAULT_N: "1.20.4"
+      VAULT_N_1: "1.19.10"
+      VAULT_N_2: "1.18.15"
+      VAULT_LTS_1: "1.16.26"
   copyright:
     uses: hashicorp/vault-workflows-common/.github/workflows/copyright-headers.yaml@main
   go-checks:

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ LDFLAGS?="-X '$(PKG).BuildVersion=$(VERSION)' \
 	-X '$(PKG).BuildDate=$(BUILD_DATE)' \
 	-X '$(PKG).GoVersion=$(shell go version)'"
 CSI_DRIVER_VERSION=1.5.3
-VAULT_HELM_VERSION=0.30.1
-VAULT_VERSION=1.20.3
+VAULT_HELM_VERSION=0.31.0
+VAULT_VERSION=1.20.4
 GOLANGCI_LINT_FORMAT?=colored-line-number
 
 VAULT_VERSION_ARGS=--set server.image.tag=$(VAULT_VERSION) --set csi.agent.image.tag=$(VAULT_VERSION)


### PR DESCRIPTION
Vault Helm v0.31.0 has been released; updating it here for use in CI along with the latest Vault versions.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
