### PR TITLE
Add support for linux/ppc64le (UBI only)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["arm", "arm64", "386", "amd64", "s390x"]
+        arch: ["arm", "arm64", "386", "amd64", "s390x", "ppc64le"]
       fail-fast: true
 
     name: Go linux ${{ matrix.arch }} build
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["arm64", "amd64", "s390x"]
+        arch: ["arm64", "amd64", "s390x", "ppc64le"]
     env:
       repo: ${{github.event.repository.name}}
       version: ${{needs.get-product-version.outputs.product-version}}
@@ -127,8 +127,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Docker Build (Action) ${{ matrix.arch }}
-        # linux/s390x images can only ever be published the Red Hat catalog. In the future they may be pushed to ICR as well.
-        if: ${{ matrix.arch != 's390x'}}
+        # linux/s390x and linux/ppc64le images can only ever be published to the Red Hat catalog and ICR.
+        if: ${{ matrix.arch != 's390x' && matrix.arch != 'ppc64le'}}
         uses: hashicorp/actions-docker-build@v2
         with:
           version: ${{env.version}}
@@ -140,8 +140,8 @@ jobs:
             icr.io/cpopen/ibm-vault/${{env.repo}}:${{env.version}}-ubi
 
       - name: Docker Build (Action) ${{ matrix.arch }}
-        # linux/s390x images are published to the Red Hat catalog and ICR.
-        if: ${{ matrix.arch == 's390x'}}
+        # linux/s390x and linux/ppc64le images are published to the Red Hat catalog and ICR.
+        if: ${{ matrix.arch == 's390x' || matrix.arch == 'ppc64le'}}
         uses: hashicorp/actions-docker-build@v2
         with:
           version: ${{env.version}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,16 +119,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["arm64", "amd64", "s390x", "ppc64le"]
+        arch: ["arm64", "amd64"]
     env:
       repo: ${{github.event.repository.name}}
       version: ${{needs.get-product-version.outputs.product-version}}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Docker Build (Action) ${{ matrix.arch }}
-        # linux/s390x and linux/ppc64le images can only ever be published to the Red Hat catalog and ICR.
-        if: ${{ matrix.arch != 's390x' && matrix.arch != 'ppc64le'}}
+      - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v2
         with:
           version: ${{env.version}}
@@ -139,9 +137,25 @@ jobs:
             docker.io/hashicorp/${{env.repo}}:${{env.version}}-ubi
             icr.io/cpopen/ibm-vault/${{env.repo}}:${{env.version}}-ubi
 
-      - name: Docker Build (Action) ${{ matrix.arch }}
-        # linux/s390x and linux/ppc64le images are published to the Red Hat catalog and ICR.
-        if: ${{ matrix.arch == 's390x' || matrix.arch == 'ppc64le'}}
+  build-ubi-ibm:
+    name: UBI IBM ${{ matrix.arch }} build
+    needs:
+      - get-product-version
+      - build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ["s390x", "ppc64le"]
+    env:
+      repo: ${{github.event.repository.name}}
+      version: ${{needs.get-product-version.outputs.product-version}}
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Docker Build (Action)
+        # linux/s390x and linux/ppc64le images are published to the Red Hat catalog and ICR only.
+        # Binary version verification is skipped — the GitHub Actions runner cannot execute
+        # cross-architecture Docker containers natively.
         uses: hashicorp/actions-docker-build@v2
         with:
           version: ${{env.version}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Docker Build (Action)
+      - name: Docker Build (Action) ${{ matrix.arch }}
         uses: hashicorp/actions-docker-build@v2
         with:
           version: ${{env.version}}
@@ -152,10 +152,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Docker Build (Action)
+      - name: Docker Build (Action) ${{ matrix.arch }}
         # linux/s390x and linux/ppc64le images are published to the Red Hat catalog and ICR only.
-        # Binary version verification is skipped — the GitHub Actions runner cannot execute
-        # cross-architecture Docker containers natively.
         uses: hashicorp/actions-docker-build@v2
         with:
           version: ${{env.version}}

--- a/.release/vault-csi-provider-artifacts.hcl
+++ b/.release/vault-csi-provider-artifacts.hcl
@@ -9,6 +9,7 @@ artifacts {
     "vault-csi-provider_${version}_linux_arm.zip",
     "vault-csi-provider_${version}_linux_arm64.zip",
     "vault-csi-provider_${version}_linux_s390x.zip",
+    "vault-csi-provider_${version}_linux_ppc64le.zip",
   ]
   container = [
     "vault-csi-provider_default_linux_386_${version}_${commit_sha}.docker.tar",
@@ -22,5 +23,8 @@ artifacts {
     # s390x is published to the Red Hat catalog and ICR
     "vault-csi-provider_release-ubi_linux_s390x_${version}_${commit_sha}.docker.redhat.tar",
     "vault-csi-provider_release-ubi_linux_s390x_${version}_${commit_sha}.docker.tar",
+    # ppc64le is published to the Red Hat catalog and ICR
+    "vault-csi-provider_release-ubi_linux_ppc64le_${version}_${commit_sha}.docker.redhat.tar",
+    "vault-csi-provider_release-ubi_linux_ppc64le_${version}_${commit_sha}.docker.tar",
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+Build:
+* Add `ppc64le` (IBM Power) architecture support: build and publish UBI-based images to `icr.io/cpopen/ibm-vault` and `quay.io/redhat-isv-containers` ([#514](https://github.com/hashicorp/vault-csi-provider/pull/514))
+
 ## 1.7.3 (June 25, 2026)
 
 * Test with Vault 2.0.3, 1.21.8, 1.20.13, 1.19.19

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ ci-build: clean
 test:
 	go test ./...
 
+# --load required for Podman/buildx: exports image into local daemon store
 image:
 	docker build \
 		--build-arg GO_VERSION=$(shell cat .go-version) \
@@ -85,6 +86,7 @@ image:
 		--tag $(IMAGE_TAG) \
 		.
 
+# --load required for Podman/buildx: exports image into local daemon store
 image-ubi:
 	docker build \
 		--build-arg PRODUCT_VERSION=$(VERSION) \

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ image:
 		--build-arg GO_VERSION=$(shell cat .go-version) \
 		--target dev \
 		--no-cache \
+		--load \
 		--tag $(IMAGE_TAG) \
 		.
 
@@ -90,6 +91,7 @@ image-ubi:
 		--build-arg PRODUCT_REVISION=$(VERSION) \
 		--target release-ubi \
 		--no-cache \
+		--load \
 		--tag $(IMAGE_TAG) \
 		.
 


### PR DESCRIPTION
## Description

Adds `ppc64le` (IBM Power) architecture support to the vault-csi-provider
build and release pipeline. This enables vault-csi-provider images to be built,
pushed, and distributed for `ppc64le` environments alongside the existing
`amd64`, `arm64`, `386`, `arm`, and `s390x` architectures.

## Changes

### `.github/workflows/build.yml`
- Added `ppc64le` to the binary build matrix (`build` job), which now covers
  `arm`, `arm64`, `386`, `amd64`, `s390x`, `ppc64le`.
- Refactored UBI image building for IBM architectures into a dedicated
  `build-ubi-ibm` job (matrix: `["s390x", "ppc64le"]`), separate from the
  existing `build-ubi` job (matrix: `["arm64", "amd64"]`). This removes the
  need for per-step `if:` conditionals in the shared job.
- `build-ubi` now runs unconditionally for `arm64`/`amd64`, publishing to
  Docker Hub, Amazon ECR, and ICR.
- `build-ubi-ibm` publishes images only to `icr.io/cpopen/ibm-vault/` and
  `quay.io/redhat-isv-containers` (no Docker Hub / ECR), with no binary version
  check (cross-arch execution is not supported on the GitHub Actions runner).

### `.release/vault-csi-provider-artifacts.hcl`
- Registered the `ppc64le` binary zip artifact:
  `vault-csi-provider_${version}_linux_ppc64le.zip`.
- Registered the `ppc64le` UBI-based Docker tarballs:
  - `vault-csi-provider_release-ubi_linux_ppc64le_${version}_${commit_sha}.docker.redhat.tar`
  - `vault-csi-provider_release-ubi_linux_ppc64le_${version}_${commit_sha}.docker.tar`

### `Makefile`
- Added `--load` flag to the `docker build` command in both the `image` and
  `image-ubi` targets so locally built images are loaded into the Docker daemon
  (enables compatibility with Podman).

## Why

IBM Power (`ppc64le`) is a platform used in enterprise and regulated
environments, including OpenShift on IBM Power. This change extends
vault-csi-provider's multi-arch support to include `ppc64le` so it can be
deployed natively on those platforms without emulation.

## Testing

- `ppc64le` UBI image is manually tested in an OCP cluster and all integration
  tests passed.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
